### PR TITLE
Syntax Highlighting with highlight.js

### DIFF
--- a/src/JDS.jl
+++ b/src/JDS.jl
@@ -37,6 +37,16 @@ function build()
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());  gtag('config', 'G-2RKMTDS1S8');
     </script>
+
+    <!-- Highlight.js -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.0.1/build/styles/default.min.css">
+    <script src="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.0.1/build/highlight.min.js"></script>
+    <!-- and it's easy to individually load additional languages -->
+    <script src="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.0.1/build/languages/julia.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.0.1/build/languages/julia-repl.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.0.1/build/languages/python.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.0.1/build/languages/python-repl.min.js"></script>
+    <script>hljs.highlightAll();</script>
     """
     Books.build_all(; extra_head)
 end


### PR DESCRIPTION
This is a PR to incorporate syntax highlighting to code blocks using [highlight.js](https://highlightjs.org/usage/).

I did already the extra script calls necessary in the `<head>` tag inside the `build()` function. I explicitely asked to download additional styles such as `julia` and `julia-repl`, and `python` and `python-repl`. We can have more than 180 different languagues, check [here](https://github.com/highlightjs/highlight.js/blob/main/SUPPORTED_LANGUAGES.md) for aliases.

Now we need to add this to every code chunk that has a language.

```html
<pre><code class="language-alias">...</code></pre>
```

where alias would be the language alias. Probably the default should be `julia`. We would also want to add an option to flag a code output as `python` (since we are using it in Why Julia section).

I also included `julia-repl` and `python-repl` if we need syntax highlighting for those languages REPL.

I don't know how to do this in HTML, CSS. But I hoped that my initital efforts were of help.

If you could point me towards documentation or how to do it. I would glad do it. I think that this PR should also motivate a new feature add-on on Books.jl.