### PR TITLE
Enable verification of crossrefs

### DIFF
--- a/contents/index.md
+++ b/contents/index.md
@@ -6,7 +6,7 @@ This file is only included on the website.
 
 Welcome! This is an open source and open access book on how to do **Data Science using [Julia](https://julialang.org)**.
 Our target audience are PhD candidates from all fields of applied sciences.
-Industry analysts, upcoming and established researchers are also welcome as readers.
+Industry analysts, upcoming and established researchers are also welcome.
 
 The book is also available as [**PDF**](/juliadatascience.pdf){target="_blank"}.
 
@@ -20,7 +20,7 @@ Jose Storopoli, Rik Huijzer and Lazaro Alonso (2021). Julia Data Science. https:
 
 Or in BibTeX format:
 
-```bibtex
+```plaintext
 @book{storopolihuijzer2021juliadatascience,
   title = {Julia Data Science},
   author = {Storopoli, Jose and Huijzer, Rik and Alonso, Lazaro},

--- a/src/JDS.jl
+++ b/src/JDS.jl
@@ -54,7 +54,7 @@ function build()
       gtag('js', new Date());  gtag('config', 'G-2RKMTDS1S8');
     </script>
     """
-    Books.build_all(; extra_head)
+    Books.build_all(; extra_head, fail_on_error=true)
 end
 
 end # module


### PR DESCRIPTION
I did a reasonably big refactor of Books.jl again (https://github.com/rikhuijzer/Books.jl/pull/170).

Now, some small bugs are fixed, the package is more robust and Books.jl is about 10% more quick in building the HTML files for JuliaDataScience.

In this PR, I enable the `fail_on_error` option for `Books.build_all`. With this option, the build will fail on missing cross-references.