### PR TITLE
Fix not evaluating code blocks

### DIFF
--- a/contents/julia_101.md
+++ b/contents/julia_101.md
@@ -459,6 +459,7 @@ end
 In that case we can do two things:
 
 1. We can, analogously as the return values, define two variables to hold the function return values, one for each return value:
+
    ```jl
    scob(
    """
@@ -469,6 +470,7 @@ In that case we can do two things:
    ```
 
 2. Or we can define just one variable to hold the function return values and access them with either `first` or `last`:
+
    ```jl
    scob(
    """


### PR DESCRIPTION
Thanks to https://github.com/rikhuijzer/Books.jl/pull/180, the indentation is now fixed.

I've disallowed blocks without a newline before the block since that is more in line with how it works for non-indented code blocks. Therefore, this PR adds a newline before the two indented blocks which didn't have a newline in front.