### PR TITLE
added funding button

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: JuliaDataScience


### PR DESCRIPTION
I think this implements the funding button with the GitHub Sponsors on our repo. Like the pic above:
![image](https://user-images.githubusercontent.com/43353831/131579854-e44dfa74-cca1-4fbb-96b6-61010a86d6ca.png)

The documentation can be viewed here: https://docs.github.com/en/github/administering-a-repository/managing-repository-settings/displaying-a-sponsor-button-in-your-repository

Please check if I am doing this right.
