### PR TITLE
Set CSV.jl compat to 0.9

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -33,7 +33,7 @@ XLSX = "fdbf4ff8-1666-58a4-91e7-1b58723a45e0"
 
 [compat]
 Books = "0.7"
-CSV = "0.8"
+CSV = "0.9"
 CairoMakie = "0.6"
 CategoricalArrays = "0.10"
 ColorSchemes = "3"


### PR DESCRIPTION
I manually compared the local page to `https://juliadatascience.io/load_save` and didn't see any problems.

We should, probably, add tests to automate this manual skimming, but I currently don't think it's worth the time. We just need to keep in mind that we add a test whenever we get issue reports in the future about wrong outputs.