### PR TITLE
Add roadmap

### DIFF
--- a/contents/appendix.md
+++ b/contents/appendix.md
@@ -5,3 +5,13 @@ This book is built with Julia `jl string(VERSION)` and the following packages:
 ```jl
 JDS.pkg_deps()
 ```
+
+```jl
+let
+    date = today()
+    hour = Dates.hour(now())
+    min = Dates.minute(now())
+
+    "Build: $date $hour:$min UTC"
+end
+```

--- a/contents/index.md
+++ b/contents/index.md
@@ -21,9 +21,10 @@ Roughly, the status is as follows:
 - [x] 1. Preface
 - [x] 2. Why Julia?
 - [x] 3. Julia Basics
-- [ ] 4. DataFrames.jl
+- [x] 4. DataFrames.jl
 - [ ] 5. Plots.jl
 - [x] 6. Makie.jl
+- [ ] Statistics
 - [ ] Review complete book
 - [ ] Publish with Amazon Kindle Direct Publishing
 

--- a/contents/index.md
+++ b/contents/index.md
@@ -36,7 +36,7 @@ Of course, data science is about more things than just tables, basic statistics 
 We want to cover more topics, but we have scheduled them for the second edition of the book.
 For now, the planned topics for the second edition are:
 
-- More statistics (probably, `Distributions.jl`, `GLM.jl` and `HypothesisTests.jl`)
+- More statistics (probably, descriptive statistics, `Distributions.jl`)
 - Plotting via `AlgebraOfGraphics.jl`.
 - Machine learning (probably, `MLJ.jl` and `Flux.jl`)
 - Bayesian statistics (`Turing.jl`)

--- a/contents/index.md
+++ b/contents/index.md
@@ -30,6 +30,17 @@ Roughly, the status is as follows:
 Also, some small issues have to be fixed like _footnotes not working on the website_.
 For details about the status, see the [JuliaDataScience](https://github.com/JuliaDataScience/JuliaDataScience) GitHub repository.
 
+### Roadmap {-}
+
+Of course, data science is about more things than just tables, basic statistics and plotting.
+We want to cover more topics, but we have scheduled them for the second edition of the book.
+For now, the planned topics for the second edition are:
+
+- More statistics (probably, `Distributions.jl`, `GLM.jl` and `HypothesisTests.jl`)
+- Plotting via `AlgebraOfGraphics.jl`.
+- Machine learning (probably, `MLJ.jl` and `Flux.jl`)
+- Bayesian statistics (`Turing.jl`)
+
 ### Citation info {-}
 
 To cite the content, please use:
@@ -47,10 +58,4 @@ Or in BibTeX format:
   url = {https://juliadatascience.io},
   year = {2021}
 }
-```
-
-```{=comment}
-Once the book is launched in Amazon we should add something like: "You can also buy this book in printed version at Amazon.com"
-
-We need a nice cover image...
 ```

--- a/metadata.yml
+++ b/metadata.yml
@@ -4,7 +4,7 @@ subtitle: ""
 book: true
 author: "Jose Storopoli, Rik Huijzer and Lazaro Alonso"
 html-license: <a href="http://creativecommons.org/licenses/by-nc-sa/4.0/">CC BY-NC-SA 4.0</a>
-pdf-footer: "\\url{https://github.com/juliadatascience/juliadatascience}"
+pdf-footer: "\\textbf{DRAFT} - See \\url{https://juliadatascience.io} for the latest version."
 tex-license: Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International (CC BY-NC-SA 4.0)
 lang: en-US
 tags: [JuliaLang, Data Science, Data Visualization, Data Manipulation, Data Analysis]


### PR DESCRIPTION
Closes #113.
 
@storopoli, I couldn't figure out to add the roadmap nicely to the PDF. Instead, there is now clear message at the bottom of every second page which redirects users to the homepage:

![image](https://user-images.githubusercontent.com/20724914/132718517-c1af231b-e573-480e-bd05-f543e5ce5f26.png)

Also, each generated PDF now contains the date and time of the build.