### PR TITLE
Document using versus import

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -38,7 +38,7 @@
   extra_directories = [
     "images"
   ]
-  
+
   online_url = "https://juliadatascience.io"
 
   output_filename = "juliadatascience"

--- a/contents/dataframes_load_save.md
+++ b/contents/dataframes_load_save.md
@@ -168,10 +168,16 @@ pkg> add XLSX
 
 and load it with:
 
-```jl
-sc("""
-import XLSX
-""")
+```
+using XLSX
+```
+
+or
+
+```
+using XLSX:
+    readxlsx,
+    writetable
 ```
 
 To write files, we define a little helper function for data and column names:

--- a/contents/dataframes_load_save.md
+++ b/contents/dataframes_load_save.md
@@ -158,24 +158,11 @@ There are multiple Julia packages to read Excel files.
 In this book, we will only look at [`XLSX.jl`](https://github.com/felipenoris/XLSX.jl), because it is the most actively maintained package in the Julia's ecosystem that deals with Excel data.
 As a second benefit, `XLSX.jl` is written in pure Julia, which makes it easy for us to inspect and understand what's going on under the hood.
 
-Install the `XSLX.jl` package via:
-
-```
-julia> ]
-
-pkg> add XLSX
-```
-
-and load it with:
-
-```
-using XLSX
-```
-
-or
+Load `XLSX.jl` via
 
 ```
 using XLSX:
+    eachtablerow,
     readxlsx,
     writetable
 ```
@@ -198,19 +185,20 @@ When reading it back, we will see that `XLSX.jl` puts the data in a `XLSXFile` t
 sco("""
 JDS.inside_tempdir() do # hide
 path = write_grades_xlsx()
-xf = XLSX.readxlsx(path)
+xf = readxlsx(path)
 end # hide
 """)
 ```
 
 ```jl
-sco("""
-JDS.inside_tempdir() do # hide
-xf = XLSX.readxlsx(write_grades_xlsx())
-sheet = xf["Sheet1"]
-XLSX.eachtablerow(sheet) |> DataFrame
-end # hide
-"""; process=without_caption_label)
+s = """
+    JDS.inside_tempdir() do # hide
+    xf = readxlsx(write_grades_xlsx())
+    sheet = xf["Sheet1"]
+    eachtablerow(sheet) |> DataFrame
+    end # hide
+    """
+sco(s; process=without_caption_label)
 ```
 
 Notice that we cover just the basics of `XLSX.jl` but more powerful usage and customizations are available.

--- a/contents/julia_basics.md
+++ b/contents/julia_basics.md
@@ -108,7 +108,7 @@ Here, I will restrict the output to the first 5 rows:
 s = """
     first(methodswith(Int64), 5)
     """
-sco(s; process=Books.catch_show)
+sco(s; process=catch_show)
 ```
 
 ### User-defined Types {#sec:struct}
@@ -587,7 +587,7 @@ Let's see what we can do with a `String` for example:
 
 ```jl
 s = "first(methodswith(String), 5)"
-sco(s; process=Books.catch_show)
+sco(s; process=catch_show)
 ```
 
 ### Broadcasting Operators and Functions {#sec:broadcasting}
@@ -2603,7 +2603,7 @@ Let's just show the first 4 lines of our downloaded file with the `readlines` fu
 sco(
 """
 readlines(my_file)[1:4]
-"""; process=Books.catch_show
+"""; process=catch_show
 )
 ```
 

--- a/contents/notation.md
+++ b/contents/notation.md
@@ -69,3 +69,9 @@ From the style guide, we attempt to adhere specifically to:
 - Do not use unicode symbols in inline code.
   This is simply a bug in the PDF generation that we have to workaround for now.
 - The line before each code block ends with a colon (:) to indicate that the line belongs to the code block.
+- Prefer `using A: foo` over `using A` when not using the REPL because the latter loads all exported symbols [@jump2021using].
+    The reason is that when `using A; using B;`, these statements can cause your software to break in the future when both package `A` and `B` decide to export a symbol with the same name.
+    When using `using A: foo`, all loaded symbols are explicit so they cannot accidentaly collide.
+    Also, prefer `using A: foo` over `import A: foo` because the latter makes it easy to accidentaly extend `foo`.
+    Note that `from <module> import *` is also discouraged in Python [@pep8].
+

--- a/contents/notation.md
+++ b/contents/notation.md
@@ -72,9 +72,18 @@ From the style guide, we attempt to adhere specifically to:
 
 #### Loading of symbols
 
-Prefer to load symbols explicitly, that is, prefer `using A: foo` over `using A` when not using the REPL [see also, @jump2021using] because the latter loads all exported symbols.
-Also, prefer `using A: foo` over `import A: foo` because the latter makes it easy to accidentaly extend `foo`.
-Note that implicit loading of symbols via `from <module> import *` is also discouraged in Python [@pep8].
+Prefer to load symbols explicitly, that is, prefer `using A: foo` over `using A` when not using the REPL [see also, @jump2021using].
+In this context, a symbol means an identifier to an object.
+For example, even if it doesn't look like it normally, internally `DataFrame`, `π` and `CSV` are all symbols.
+We notice this when we use a introspective method from Julia such as `isdefined`:
+
+```jl
+scob("isdefined(Main, :π)")
+```
+
+Next to being explicit when using `using`, also prefer `using A: foo` over `import A: foo` because the latter makes it easy to accidentaly extend `foo`.
+Note that this isn't an advise for Julia only:
+implicit loading of symbols via `from <module> import *` is also discouraged in Python [@pep8].
 
 The reason why being explicit is important is related to semantic versioning.
 With semantic versioning (<http://semver.org>), the version number is related to whether a package is, so called, _breaking_ or not.

--- a/contents/notation.md
+++ b/contents/notation.md
@@ -69,9 +69,18 @@ From the style guide, we attempt to adhere specifically to:
 - Do not use unicode symbols in inline code.
   This is simply a bug in the PDF generation that we have to workaround for now.
 - The line before each code block ends with a colon (:) to indicate that the line belongs to the code block.
-- Prefer `using A: foo` over `using A` when not using the REPL because the latter loads all exported symbols [@jump2021using].
-    The reason is that when `using A; using B;`, these statements can cause your software to break in the future when both package `A` and `B` decide to export a symbol with the same name.
-    When using `using A: foo`, all loaded symbols are explicit so they cannot accidentaly collide.
-    Also, prefer `using A: foo` over `import A: foo` because the latter makes it easy to accidentaly extend `foo`.
-    Note that `from <module> import *` is also discouraged in Python [@pep8].
 
+#### Loading of symbols
+
+Prefer to load symbols explicitly, that is, prefer `using A: foo` over `using A` when not using the REPL [see also, @jump2021using] because the latter loads all exported symbols.
+Also, prefer `using A: foo` over `import A: foo` because the latter makes it easy to accidentaly extend `foo`.
+Note that implicit loading of symbols via `from <module> import *` is also discouraged in Python [@pep8].
+
+The reason why being explicit is important is related to semantic versioning.
+With semantic versioning (<http://semver.org>), the version number is related to whether a package is, so called, _breaking_ or not.
+For example, a non-breaking update for package `A` is when the package goes from version `0.2.2` to `0.2.3`.
+With such a non-breaking version update, you don't need to worry that your package will break, that is, throw an error or change behavior.
+If package `A` goes from `0.2` to `1.0`, then that's a breaking update and you can expect that you need some changes in your package to make `A` work again.
+**However**, exporting extra symbols is considered a non-breaking change.
+So, with implicit loading of symbols, **non-breaking changes can break your package**.
+That's why it's good practice to explicitly load symbols.

--- a/pandoc/references.bib
+++ b/pandoc/references.bib
@@ -70,7 +70,7 @@
 @misc{jump2021using,
   title = {JuMP Style Guide},
   year = 2021,
-  howpublished = {\url{https://jump.dev/JuMP.jl/v0.21/developers/style/#using-vs.-import}},
+  url = {https://jump.dev/JuMP.jl/v0.21/developers/style/#using-vs.-import},
   note = {Accessed: 2021-09-19}
 }
 

--- a/pandoc/references.bib
+++ b/pandoc/references.bib
@@ -67,6 +67,13 @@
   howpublished = {Zenodo}
 }
 
+@misc{jump2021using,
+  title = {JuMP Style Guide},
+  year = 2021,
+  howpublished = {\url{https://jump.dev/JuMP.jl/stable/developers/style/#using-vs.-import}},
+  note = {Accessed: 2021-09-19}
+}
+
 @article{khan2014big,
   title     = {Big data: survey, technologies, opportunities, and challenges},
   author    = {Khan, Nawsher and Yaqoob, Ibrar and Hashem, Ibrahim Abaker Targio and Inayat, Zakira and Mahmoud Ali, Waleed Kamaleldin and Alam, Muhammad and Shiraz, Muhammad and Gani, Abdullah},
@@ -119,6 +126,15 @@
   journal    = {Nature},
   language   = {en},
   number     = {7767}
+}
+
+@techreport{pep8,
+  author = {Guido {van Rossum} and Barry Warsaw and Nick Coghlan},
+  title = {Style Guide for {Python} Code},
+  year = {2001},
+  type = {PEP},
+  number = {8},
+  url = {https://www.python.org/dev/peps/pep-0008/},
 }
 
 @book{senguptaJuliaHighPerformance2019,

--- a/pandoc/references.bib
+++ b/pandoc/references.bib
@@ -70,7 +70,7 @@
 @misc{jump2021using,
   title = {JuMP Style Guide},
   year = 2021,
-  howpublished = {\url{https://jump.dev/JuMP.jl/stable/developers/style/#using-vs.-import}},
+  howpublished = {\url{https://jump.dev/JuMP.jl/v0.21/developers/style/#using-vs.-import}},
   note = {Accessed: 2021-09-19}
 }
 

--- a/src/JDS.jl
+++ b/src/JDS.jl
@@ -44,7 +44,9 @@ using LinearAlgebra
 using Makie
 using Random
 using Statistics
-using StatsBase
+using StatsBase:
+    mad,
+    mode
 using TestImages
 using XLSX:
     readxlsx,

--- a/src/JDS.jl
+++ b/src/JDS.jl
@@ -62,6 +62,7 @@ using StatsBase:
     mode
 using TestImages
 using XLSX:
+    eachtablerow,
     readxlsx,
     writetable
 end # @reexport

--- a/src/JDS.jl
+++ b/src/JDS.jl
@@ -1,13 +1,26 @@
 module JDS
 
-import XLSX
 import Pkg
 import Plots
 
 using Reexport: @reexport
 
 @reexport begin
-using Books
+using Books:
+    @sc,
+    @sco,
+    Options,
+    build_all,
+    catch_show,
+    clean_stacktrace,
+    code_block,
+    gen,
+    output_block,
+    sc,
+    sco,
+    scob,
+    serve,
+    without_caption_label
 using CSV
 using CairoMakie
 using CategoricalArrays
@@ -94,11 +107,11 @@ This method is called during CI.
 """
 function build()
     println("Building JDS")
-    Books.gen(; fail_on_error=true)
+    gen(; fail_on_error=true)
     extra_head = """
     <script src="https://cdn.usefathom.com/script.js" data-site="EEJXHKTE" defer></script>
     """
-    Books.build_all(; extra_head, fail_on_error=true)
+    build_all(; extra_head, fail_on_error=true)
 end
 
 end # module

--- a/src/JDS.jl
+++ b/src/JDS.jl
@@ -4,28 +4,52 @@ import XLSX
 import Pkg
 import Plots
 
-using Reexport
-@reexport using Books
-@reexport using CSV
-@reexport using CairoMakie
-@reexport using CategoricalArrays
-@reexport using ColorSchemes
-@reexport using Colors
-@reexport using DataFrames
-@reexport using Dates
-@reexport using Distributions
-@reexport using Downloads
-@reexport using GLMakie
-@reexport using LaTeXStrings
-@reexport using Makie
-@reexport using Random
-@reexport using Statistics
-@reexport using StatsBase
-@reexport using InteractiveUtils
-@reexport using LinearAlgebra
-@reexport using GeometryBasics
-@reexport using FileIO
-@reexport using TestImages
+using Reexport: @reexport
+
+@reexport begin
+using Books
+using CSV
+using CairoMakie
+using CategoricalArrays
+using ColorSchemes
+using Colors
+using DataFrames:
+    ByRow,
+    DataFrame,
+    DataFrameRow,
+    Not,
+    antijoin,
+    combine,
+    crossjoin,
+    filter,
+    groupby,
+    innerjoin,
+    leftjoin,
+    outerjoin,
+    rightjoin,
+    select!,
+    select,
+    semijoin,
+    subset,
+    transform
+using Dates
+using Distributions
+using Downloads
+using FileIO
+using GLMakie
+using GeometryBasics
+using InteractiveUtils
+using LaTeXStrings
+using LinearAlgebra
+using Makie
+using Random
+using Statistics
+using StatsBase
+using TestImages
+using XLSX:
+    readxlsx,
+    writetable
+end # @reexport
 
 const SMALL_IM_ATTR = "width=70%"
 

--- a/src/df.jl
+++ b/src/df.jl
@@ -96,7 +96,7 @@ function write_xlsx(name, df::DataFrame)
     path = "$name.xlsx"
     data = collect(eachcol(df))
     cols = names(df)
-    XLSX.writetable(path, data, cols)
+    writetable(path, data, cols)
 end
 
 function write_grades_xlsx()

--- a/src/df.jl
+++ b/src/df.jl
@@ -53,11 +53,6 @@ function names_grades2()
     df[!, :name]
 end
 
-# Should fix this in Books.jl
-function Books.convert_output(path, expr, out::DataFrameRow; kwargs...)
-    Books.convert_output(path, expr, DataFrame(out); kwargs...)
-end
-
 function grade_2020(i::Int)
     df = grades_2020()
     df[i, :]

--- a/src/environment.jl
+++ b/src/environment.jl
@@ -4,5 +4,5 @@ function pkg_deps()
     deps = filter(p -> !isnothing(p.version), deps)
     list = ["$(p.name) $(p.version)" for p in deps]
     sort!(list)
-    Books.code_block(string(join(list, '\n')))
+    code_block(string(join(list, '\n')))
 end

--- a/src/showcode_additions.jl
+++ b/src/showcode_additions.jl
@@ -4,7 +4,7 @@ function get_error(expr::String)
     catch e
         exc, bt = last(Base.catch_stack())
         stacktrace = sprint(Base.showerror, exc, bt)::String
-        stacktrace = Books.clean_stacktrace(stacktrace)
+        stacktrace = clean_stacktrace(stacktrace)
         lines = split(stacktrace, '\n')
         lines = lines[1:end-8]
         join(lines, '\n')


### PR DESCRIPTION
@lazarusA, in response to using Plots and Makie at the same time. I think that the most future proof solution is to use

```
@reexport begin

using Plots:
    plot,
    [...]
using Makie:
    density,
    [...]

end # @reexport
```

The rationale is added to the notation section and can also be read in the [JuMP Style Guide](https://jump.dev/JuMP.jl/stable/developers/style/#using-vs.-import).

As a proof-of-concept, I've implemented it for `DataFrames.jl` and `XLSX.jl` already.

This pattern is also used at other places. For example, in [`JETTest.jl`](https://github.com/aviatesk/JETTest.jl/blob/master/src/JETTest.jl).