### PR TITLE
Fix trailing whitespace

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,13 +1,11 @@
 name: CI
 
 on:
-  workflow_run:
+  push:
     branches:
       - main
-    workflows:
-      - Format
-    types:
-      - completed
+  pull_request:
+  workflow_dispatch:
 
 jobs:
   build-and-deploy:
@@ -16,9 +14,6 @@ jobs:
       - uses: actions/checkout@v2
         with:
           persist-credentials: false
-
-      - name: Only continue if workflow_run workflows were successful.
-        uses: ahmadnassri/action-workflow-run-wait@v1
 
       - uses: julia-actions/setup-julia@v1
         with:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,15 +1,15 @@
 name: CI
 
 on:
-  push:
-    branches:
-      - main
-  pull_request:
-  workflow_dispatch:
+  on:
+  workflow_run:
+    workflows: ["Format"]
+    types:
+      - completed
 
 jobs:
   build-and-deploy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
         with:
@@ -29,6 +29,15 @@ jobs:
             ${{ runner.os }}-test-${{ env.cache-name }}-
             ${{ runner.os }}-test-
             ${{ runner.os }}-
+
+      - shell: julia --project=format --color=yes {0}
+        run: 'using Pkg; Pkg.instantiate()'
+
+      - shell: julia --project=format --color=yes {0}
+        run: |
+          using FormatJDS
+          exitcode = project_has_trailing_whitespace() ? 1 : 0
+          exit(exitcode)
 
       - name: Install GLMakie dependencies
         run: sudo apt-get update && sudo apt-get install -y xorg-dev imagemagick mesa-utils xvfb libgl1 freeglut3-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev libxext-dev

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,9 +1,9 @@
 name: CI
 
 on:
-  on:
   workflow_run:
-    workflows: ["Format"]
+    workflows:
+      - Format
     types:
       - completed
 
@@ -14,6 +14,9 @@ jobs:
       - uses: actions/checkout@v2
         with:
           persist-credentials: false
+
+      - name: Only continue if workflow_run workflows were successful.
+        uses: ahmadnassri/action-workflow-run-wait@v1
 
       - uses: julia-actions/setup-julia@v1
         with:
@@ -65,3 +68,4 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           force_orphan: true
           publish_dir: ./_build/
+

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   BuildAndDeploy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  build-and-deploy:
+  Build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  Build:
+  BuildAndDeploy:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -29,15 +29,6 @@ jobs:
             ${{ runner.os }}-test-${{ env.cache-name }}-
             ${{ runner.os }}-test-
             ${{ runner.os }}-
-
-      - shell: julia --project=format --color=yes {0}
-        run: 'using Pkg; Pkg.instantiate()'
-
-      - shell: julia --project=format --color=yes {0}
-        run: |
-          using FormatJDS
-          exitcode = project_has_trailing_whitespace() ? 1 : 0
-          exit(exitcode)
 
       - name: Install GLMakie dependencies
         run: sudo apt-get update && sudo apt-get install -y xorg-dev imagemagick mesa-utils xvfb libgl1 freeglut3-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev libxext-dev

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -2,6 +2,8 @@ name: CI
 
 on:
   workflow_run:
+    branches:
+      - main
     workflows:
       - Format
     types:

--- a/.github/workflows/Format.yml
+++ b/.github/workflows/Format.yml
@@ -23,5 +23,5 @@ jobs:
         run: |
           using FormatJDS
           exitcode = FormatJDS.project_has_trailing_whitespace() ? 1 : 0
-          println(exitcode ? 1 : "Trailing whitespace found" : "No trailing whitespace found")
+          println(exitcode == 1 ? "Trailing whitespace found" : "No trailing whitespace found")
           exit(exitcode)

--- a/.github/workflows/Format.yml
+++ b/.github/workflows/Format.yml
@@ -1,0 +1,24 @@
+name: Format
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  docs:
+    name: CheckFormatting
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - shell: julia --project=format --color=yes {0}
+        run: 'import Pkg: instantiate'
+
+      - shell: julia --project=format --color=yes {0}
+        run: |
+          import FormatJDS
+          exitcode = project_has_trailing_whitespace() ? 1 : 0
+          exit(exitcode)

--- a/.github/workflows/Format.yml
+++ b/.github/workflows/Format.yml
@@ -15,10 +15,12 @@ jobs:
       - uses: actions/checkout@v2
 
       - shell: julia --project=format --color=yes {0}
-        run: 'import Pkg: instantiate'
+        run: |
+          using Pkg
+          Pkg.instantiate()
 
       - shell: julia --project=format --color=yes {0}
         run: |
-          import FormatJDS
-          exitcode = project_has_trailing_whitespace() ? 1 : 0
+          using FormatJDS
+          exitcode = FormatJDS.project_has_trailing_whitespace() ? 1 : 0
           exit(exitcode)

--- a/.github/workflows/Format.yml
+++ b/.github/workflows/Format.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   docs:
     name: CheckFormatting
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/Format.yml
+++ b/.github/workflows/Format.yml
@@ -23,4 +23,5 @@ jobs:
         run: |
           using FormatJDS
           exitcode = FormatJDS.project_has_trailing_whitespace() ? 1 : 0
+          println(exitcode ? 1 : "Trailing whitespace found" : "No trailing whitespace found")
           exit(exitcode)

--- a/contents/data_vis_makie_animations.md
+++ b/contents/data_vis_makie_animations.md
@@ -18,4 +18,4 @@ Test animation:
 
 </div>
 -->
-does it work? 
+does it work?

--- a/contents/data_vis_makie_attributes.md
+++ b/contents/data_vis_makie_attributes.md
@@ -57,7 +57,7 @@ This will collect all the `labels` you might have passed to your plotting functi
 
 ```jl
 s = """
-    CairoMakie.activate!() # hide 
+    CairoMakie.activate!() # hide
     lines(1:10, (1:10).^2; label = "x²", linewidth = 2, linestyle = nothing,
         figure = (; figure_padding = 5, resolution = (600,400),
             backgroundcolor = :grey90, fontsize = 16, font = "sans"),

--- a/contents/data_vis_makie_colors.md
+++ b/contents/data_vis_makie_colors.md
@@ -20,7 +20,7 @@ See this in action in the following example:
 ```
 
 Where, in the first two lines we have used the keyword `color` to specify our color.
-The rest is using the default cycle set of colors. 
+The rest is using the default cycle set of colors.
 Later, we will learn how to do a custom cycle.
 
 Regarding colormaps, we are already familiar with the keyword `colormap` for heatmaps and scatters.
@@ -31,7 +31,7 @@ See `?cgrad` for more information.
 
 ```jl
 scolor = """
-    CairoMakie.activate!() # hide 
+    CairoMakie.activate!() # hide
     figure = (;resolution = (400,300), font= "CMU Serif")
     axis = (; xlabel = L"x", ylabel = L"y", aspect= DataAspect())
 

--- a/contents/data_vis_makie_glmakie.md
+++ b/contents/data_vis_makie_glmakie.md
@@ -8,7 +8,7 @@ Like before, a simple plot includes, of course, lines and points. So, we will st
 
 ### Scatters and Lines
 
-For scatter plots we have two options, the first one is `scatter(x, y, z)` and the second one is `meshscatter(x, y, z)`. 
+For scatter plots we have two options, the first one is `scatter(x, y, z)` and the second one is `meshscatter(x, y, z)`.
 In the first one markers don't scale in the axis directions, but in the later they do because they are actual geometries in 3D space.
 See the next example:
 
@@ -32,7 +32,7 @@ And doing `lines` or `scatterlines` is also straightforward:
 
 Plotting a `surface` is also easy to do as well as a `wireframe` and `contour` lines in 3D.
 
-### Surfaces, wireframe, contour, contourf and contour3d 
+### Surfaces, wireframe, contour, contourf and contour3d
 
 To show these cases we'll use the following `peaks` function:
 
@@ -85,7 +85,7 @@ using LinearAlgebra
 
 Other interesting examples are a `mesh(obj)`, a `volume(x, y, z, vals)`, and a `contour(x, y, z, vals)`.
 
-### Meshes and Volumes 
+### Meshes and Volumes
 
 Drawing Meshes comes in handy when you want to plot geometries, like a `Sphere` or a Rectangle, i. e. `FRect3D`.
 Another approach to visualize points in 3D space is by calling the functions `volume` and `contour`, which implements [ray tracing](https://en.wikipedia.org/wiki/Ray_tracing_(graphics)) to simulate a wide variety of optical effects.
@@ -132,5 +132,5 @@ For our last example we will show how to do a filled curve in 3D with `band` and
 ```
 
 Finally, our journey doing 3D plots has come to an end.
-You can combine everything we exposed here to create amazing 3D images! 
+You can combine everything we exposed here to create amazing 3D images!
 Now, it's time to dig into the basic rules to create animations.

--- a/contents/data_vis_makie_layouts.md
+++ b/contents/data_vis_makie_layouts.md
@@ -1,39 +1,39 @@
 ## Layouts {#sec:makie_layouts}
 
 A complete _canvas/layout_ is defined by `Figure`, which can be filled with content after creation.
-We will start with a simple arrangement of one `Axis`, one `Legend` and one `Colorbar`. 
+We will start with a simple arrangement of one `Axis`, one `Legend` and one `Colorbar`.
 For this task we can think of the canvas as an arrangement of `rows` and `columns` in indexing a `Figure` much like a regular `Array`/`Matrix`.
 The `Axis` content will be in _row 1, column 1_, e.g. `fig[1, 1]`, the `Colorbar` in _row 1, column 2_, namely `fig[1,2]`.
-And the `Legend` in _row 2_ and across _column 1 and 2_, namely `fig[2,1:2]`. 
+And the `Legend` in _row 2_ and across _column 1 and 2_, namely `fig[2,1:2]`.
 
 
 ```jl
 @sco JDS.first_layout()
 ```
 
-This does not look good. Next, we fix the spacing problems using the following keywords and methods: 
+This does not look good. Next, we fix the spacing problems using the following keywords and methods:
 
 - `figure_padding = (left, right, bottom, top)`
-- `padding =  (left, right, bottom, top)` 
+- `padding =  (left, right, bottom, top)`
 
-Taking into account the actual size for a `Legend` or `Colorbar` is done by 
+Taking into account the actual size for a `Legend` or `Colorbar` is done by
 
 > - `tellheight = true or false`
-> - `tellwidth = true or false` 
+> - `tellwidth = true or false`
 >
 > _Setting these to `true` will take into account the actual size (height or width) for a `Legend` or `Colorbar`_.
-> Consequently, things will be resized accordingly. 
+> Consequently, things will be resized accordingly.
 
-The space between columns and rows is specified as 
+The space between columns and rows is specified as
 
 > - `colgap!(fig.layout, col, separation)`
 > - `rowgap!(fig.layout, row, separation)`
 >
-> _Column gap_ (`colgap!`), if `col` is given then the gap will be applied to that specific column. 
->_Row gap_ (`rowgap!`) ,if `row` is given then the gap will be applied to that specific row. 
+> _Column gap_ (`colgap!`), if `col` is given then the gap will be applied to that specific column.
+>_Row gap_ (`rowgap!`) ,if `row` is given then the gap will be applied to that specific row.
 
-Also, we will see how to put content into the **protrusions**, _i.e._ the space reserved for _title: `x` and `y`; either `ticks` or `label`_. 
-We do this by plotting into `fig[i, j, protrusion]` where _`protrusion`_ can be `Left()`, `Right()`, `Bottom()` and `Top()`, or for each corner `TopLeft()`, `TopRight()`, `BottomRight()`, `BottomLeft()`. 
+Also, we will see how to put content into the **protrusions**, _i.e._ the space reserved for _title: `x` and `y`; either `ticks` or `label`_.
+We do this by plotting into `fig[i, j, protrusion]` where _`protrusion`_ can be `Left()`, `Right()`, `Bottom()` and `Top()`, or for each corner `TopLeft()`, `TopRight()`, `BottomRight()`, `BottomLeft()`.
 See below how these options are being used:
 
 ```jl
@@ -41,7 +41,7 @@ See below how these options are being used:
 ```
 
 Here, having the label `(a)` in the `TopLeft()` is probably not necessary, this will only make sense for more than two plots.
-For our next example let's keep using the previous tools and some more to create a richer and complex figure. 
+For our next example let's keep using the previous tools and some more to create a richer and complex figure.
 
 You can hide decorations and axis' spines with:
 
@@ -78,7 +78,7 @@ Synchronizing your `Axis` is done via:
 > This could be useful when shared axis are desired.
 > Another way of getting shared axis will be by setting `limits!`.
 
-Setting `limits` at once or independently for each axis is done by calling 
+Setting `limits` at once or independently for each axis is done by calling
 
 > - `limits!(ax; l,r,b,t)`
 > You can also do `ylims!(low, high)` or `xlims!(low, high)`, and even open ones by doing `ylims!(low=0)` or `xlims!(high=1)`.
@@ -89,9 +89,9 @@ Now, the example:
 @sco JDS.complex_layout_double_axis()
 ```
 
-So, now our `Colorbar` needs to be horizontal and the bar ticks need to be in the lower part. 
-This is done by setting `vertical = false` and `flipaxis = false`. 
-Additionally, note that we can call many `Axis` into `fig`, or even `Colorbar`'s and `Legend`'s, and then afterwards build the layout. 
+So, now our `Colorbar` needs to be horizontal and the bar ticks need to be in the lower part.
+This is done by setting `vertical = false` and `flipaxis = false`.
+Additionally, note that we can call many `Axis` into `fig`, or even `Colorbar`'s and `Legend`'s, and then afterwards build the layout.
 
 Another common layout is a grid of squares for heatmaps:
 
@@ -99,24 +99,24 @@ Another common layout is a grid of squares for heatmaps:
 @sco JDS.squares_layout()
 ```
 
-where all labels are in the **protrusions** and each `Axis` has an `AspectData()` ratio. 
-The `Colorbar` is located in the third column and expands from row 1 up to row 2. 
+where all labels are in the **protrusions** and each `Axis` has an `AspectData()` ratio.
+The `Colorbar` is located in the third column and expands from row 1 up to row 2.
 
-The next case uses the so called `Mixed()` **alignmode**, which is especially useful when dealing with large empty spaces between `Axis` due to long ticks. 
+The next case uses the so called `Mixed()` **alignmode**, which is especially useful when dealing with large empty spaces between `Axis` due to long ticks.
 
 ```jl
 @sco JDS.mixed_mode_layout()
 ```
 
-Here, the argument `alignmode = Mixed(bottom=0)` is shifting the bounding box to the bottom, so that this will align with the panel on the left filling the space. 
+Here, the argument `alignmode = Mixed(bottom=0)` is shifting the bounding box to the bottom, so that this will align with the panel on the left filling the space.
 
-Also, see how `colsize!` and `rowsize!` are being used for different columns and rows. 
-You could also put a number instead of `Auto()` but then everything will be fixed. 
+Also, see how `colsize!` and `rowsize!` are being used for different columns and rows.
+You could also put a number instead of `Auto()` but then everything will be fixed.
 And, additionally, one could also give a `height` or `width` when defining the `Axis`, as in `Axis(fig, heigth = 50)` which will be fixed as well.
 
 ### Nested `Axis` (_subplots_)
 
-It is also possible to define a set of `Axis` (_subplots_) explicitly, and use it to build a main figure with several rows and columns. 
+It is also possible to define a set of `Axis` (_subplots_) explicitly, and use it to build a main figure with several rows and columns.
 For instance, the following its a "complicated" arrangement of `Axis`:
 
 ```jl
@@ -130,26 +130,26 @@ which, when used to build a more complex figure by doing several calls, we obtai
 ```
 
 Note that different subplot functions can be called here.
-Also, each `Axis` here is an independent part of `Figure`. 
-So that, if you need to do some `rowgap!`'s or `colsize!`'s operations, you will need to do it in each one of them independently or to all of them together. 
+Also, each `Axis` here is an independent part of `Figure`.
+So that, if you need to do some `rowgap!`'s or `colsize!`'s operations, you will need to do it in each one of them independently or to all of them together.
 
-For grouped `Axis` (_subplots_) we can use `GridLayout()` which, then, could be used to composed a more complicated `Figure`. 
+For grouped `Axis` (_subplots_) we can use `GridLayout()` which, then, could be used to composed a more complicated `Figure`.
 
 ### Nested GridLayout
 
-By using `GridLayout()` we can group subplots, allowing more freedom to build complex figures. 
+By using `GridLayout()` we can group subplots, allowing more freedom to build complex figures.
 Here, using our previous `nested_sub_plot!` we define three sub-groups and one normal `Axis`:
 
 ```jl
 @sco JDS.nested_Grid_Layouts()
 ```
 
-Now, using `rowgap!` or `colsize!` over each group is possible and `rowsize!, colsize!` can also be applied to the set of `GridLayout()`s. 
+Now, using `rowgap!` or `colsize!` over each group is possible and `rowsize!, colsize!` can also be applied to the set of `GridLayout()`s.
 
 ### Inset plots
 
 Currently, doing `inset` plots is a little bit tricky.
-Here, we show two possible ways of doing it by initially defining auxiliary functions. 
+Here, we show two possible ways of doing it by initially defining auxiliary functions.
 The first one is by doing a `BBox`, which lives in the whole `Figure` space:
 
 ```jl
@@ -163,7 +163,7 @@ Then, the `inset` is easily done, as in:
 ```
 
 where the `Box` dimensions are bound by the `Figure`'s `resolution`.
-Note, that an inset can be also outside the `Axis`. 
+Note, that an inset can be also outside the `Axis`.
 The other approach, is by defining a new `Axis` into a position `fig[i,j]` specifying his `width`, `height`, `halign` and `valign`.
 We do that in the following function:
 

--- a/contents/dataframes_performance.md
+++ b/contents/dataframes_performance.md
@@ -47,7 +47,7 @@ sco(s; process=without_caption_label)
 
 The `@allocated` macro tells us how much memory was allocated.
 In other words, **how much new information the computer had to store in its memory while running the code**.
-Let's see how they will perform: 
+Let's see how they will perform:
 
 ```jl
 s = """
@@ -203,7 +203,7 @@ By using `Base.summarysize` function we can get the underlying size, in bytes, o
 So let's quantify how much more memory we would need to have if we did not compressed our one million categorical vector:
 
 ```julia
-using Random 
+using Random
 ```
 
 ```jl

--- a/contents/preface.md
+++ b/contents/preface.md
@@ -2,7 +2,7 @@
 
 There are many programming languages and each and every one of them has its strengths and weaknesses.
 Some languages are very quick, but verbose.
-Other languages are very easy to write in, but slow. This is known as the `two-language` problem and `Julia` aims at circumventing this problem. 
+Other languages are very easy to write in, but slow. This is known as the `two-language` problem and `Julia` aims at circumventing this problem.
 Even though all three of us come from different fields, we all found the Julia language more effective for our research than languages that we've used before.
 We discuss some of our arguments in @sec:why_julia.
 Compared to other languages, Julia is one of the newest languages around.

--- a/contents/stats.md
+++ b/contents/stats.md
@@ -384,7 +384,7 @@ Like before, we provide the following advice:
 - For categorical/nominal data, use some sort of **frequency counter**[^frequency_counter]
 
 [^frequency_counter]: we would suggest to use the `StatsBase.countmap` function which returns a dictionary mapping each unique value in a given vector to its number of occurrences.
- 
+
 ## Dependence Measures {#sec:stats_dependence}
 
 Now that we covered univariate measures of central tendency and dispersion, we need to talk about bivariate measures.

--- a/contents/stats_distributions.md
+++ b/contents/stats_distributions.md
@@ -131,11 +131,11 @@ In other words, **the cdf is an accumulation of the probability we observe value
 It is defined both for discrete and continuous variables:
 
 $$ \operatorname{cdf} = P(X \leq x) =
- \begin{cases} 
+ \begin{cases}
  \sum_{k \leq x} P(k), & \text{if $X$  is discrete},\\
  \int^x_{- \infty} f(t) dt, & \text{if $X$ is continuous.}
  \end{cases} $$ {#eq:cdf}
- 
+
 In @eq:cdf we sum all values less or equal than $x$ if the distribution $X$ is discrete or we integrate from minus infinity to $x$ if the distribution $X$ is continuous.
 For example, in @fig:plot_cdf_discrete we have the cdf of a 6-sided dice.
 Notice that since the values are equally likely, the cdf scales *linearly* with the possible outcome values.

--- a/format/Project.toml
+++ b/format/Project.toml
@@ -1,0 +1,10 @@
+name = "FormatJDS"
+uuid = "adfa99fd-7844-4562-9f5d-8091726a002b"
+authors = ["Jose Storopoli", "Rik Huijzer", "Lazaro Alonso"]
+version = "0.1.0"
+
+[deps]
+JuliaFormatter = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
+
+[compat]
+JuliaFormatter = "0.16"

--- a/format/src/FormatJDS.jl
+++ b/format/src/FormatJDS.jl
@@ -1,0 +1,32 @@
+module FormatJDS
+
+using JuliaFormatter: format_file
+
+const JDS_DIR = dirname(dirname(@__DIR__))
+
+const SOURCE_FILE_EXTENSIONS = [".jl", ".md", ".bib"]
+
+export source_files
+export project_has_trailing_whitespace, remove_trailing_whitespace
+
+function is_source_file_extension(file::String)
+    _, ext = splitext(file)
+    return ext in SOURCE_FILE_EXTENSIONS
+end
+
+function source_files()
+    subdirs = [
+        "contents",
+        "pandoc",
+        "src"
+    ]
+    files = [readdir(joinpath(JDS_DIR, dir); join=true) for dir in subdirs]
+    files = collect(Iterators.flatten(files))
+    files = filter(is_source_file_extension, files)
+    return files
+end
+
+include("whitespace.jl")
+include("juliaformatter.jl")
+
+end # module

--- a/format/src/juliaformatter.jl
+++ b/format/src/juliaformatter.jl
@@ -1,0 +1,25 @@
+
+"""
+    format()
+
+Format all files in the book.
+This removes trailing whitespace by default.
+"""
+function format()::BitVector
+    return format_file.(source_files();
+        margin=500,
+        verbose=true,
+        whitespace_in_kwargs=false
+    )
+end
+
+"""
+    is_formatted()
+
+Return whether the files in the repository are formatted.
+This method is used in CI.
+"""
+function is_formatted()
+    return all(format())
+end
+

--- a/format/src/whitespace.jl
+++ b/format/src/whitespace.jl
@@ -1,0 +1,40 @@
+"""
+    line_has_trailing_whitespace(line::AbstractString)
+
+Return whether `line` has trailing whitespace.
+Assumes that `line` doesn't contain newlines.
+"""
+line_has_trailing_whitespace(line::AbstractString) = endswith(line, ' ')
+
+"""
+    file_has_trailing_whitespace(path) -> Bool
+
+Check for trailing whitespace in a naive but reasonably effective way for the file at `path`.
+Return whether the file contains trailing whitespace.
+
+Not using exising tools for this simple procedure, because it's easier to fine tune this
+code to our use-case.
+"""
+function file_has_trailing_whitespace(path)::Bool
+    lines = split(read(path, String), '\n')
+    return any(line_has_trailing_whitespace.(lines))
+end
+
+function project_has_trailing_whitespace()::Bool
+    return any(file_has_trailing_whitespace.(source_files()))
+end
+
+function remove_trailing_whitespace(path)
+    sep = '\n'
+    text = read(path, String)
+    lines = split(text, sep)
+    updated_lines = rstrip.(lines, ' ')
+    updated_text = join(updated_lines, sep)
+    write(path, updated_text)
+    return nothing
+end
+
+function remove_trailing_whitespace()
+    remove_trailing_whitespace.(source_files())
+    return nothing
+end

--- a/src/JDS.jl
+++ b/src/JDS.jl
@@ -1,6 +1,6 @@
 module JDS
 
-import Pkg
+import Pkg 
 import Plots
 
 using Reexport: @reexport

--- a/src/JDS.jl
+++ b/src/JDS.jl
@@ -1,6 +1,6 @@
 module JDS
 
-import Pkg 
+import Pkg
 import Plots
 
 using Reexport: @reexport

--- a/src/bezier.jl
+++ b/src/bezier.jl
@@ -5,7 +5,7 @@ function ellipse(u; a = 2, b = 3, h = 0, k = 0)
 end
 
 # https://github.com/dronir/Bezier.jl
-# it's not longer in the registery
+# it's not longer in the registry
 struct BezierCurve
     Xcoef::Vector{Float64}
     Ycoef::Vector{Float64}

--- a/src/bezier.jl
+++ b/src/bezier.jl
@@ -5,7 +5,7 @@ function ellipse(u; a = 2, b = 3, h = 0, k = 0)
 end
 
 # https://github.com/dronir/Bezier.jl
-# it's not longer in the registery 
+# it's not longer in the registery
 struct BezierCurve
     Xcoef::Vector{Float64}
     Ycoef::Vector{Float64}

--- a/src/front-cover.jl
+++ b/src/front-cover.jl
@@ -41,12 +41,12 @@ function front_cover(; resolution=(1200, 2400))
     CairoMakie.activate!()
     with_theme(theme_black()) do
         #589.44, 884.16
-        # Warning, there is not actual structure in this code, 
-        # things are messy and all around. 
+        # Warning, there is not actual structure in this code,
+        # things are messy and all around.
         fig = Figure(resolution=(1768,2652))
-        ax1 = Axis3(fig[1,1], perspectiveness = 0.5,  azimuth = 7.19, elevation = 0.57,  
+        ax1 = Axis3(fig[1,1], perspectiveness = 0.5,  azimuth = 7.19, elevation = 0.57,
                 xlabel = "x label", ylabel = "y label", zlabel = "z label",
-                aspect = (1,1,1)) 
+                aspect = (1,1,1))
         ax2 = Axis(fig[2,1], aspect = AxisAspect(1))
         ax3 = Axis(fig[3,1], aspect = AxisAspect(1))
         ax4 = Axis(fig[4,1],  aspect = AxisAspect(1))
@@ -66,16 +66,16 @@ function front_cover(; resolution=(1200, 2400))
 
         #ax15 = Axis3(fig[3,3], perspectiveness = 0.5, azimuth = 1π, aspect = (1,1,1))
 
-        axs = [ax1, ax2, ax3, ax4, ax5, ax6, ax7, ax8, ax9, 
-            ax10, 
+        axs = [ax1, ax2, ax3, ax4, ax5, ax6, ax7, ax8, ax9,
+            ax10,
             ax11,
-            ax12, ax13, 
+            ax12, ax13,
             ax14, ax15, ax16]
 
         ms = 20
 
-        meshscatter!(ax1, positions, color = vec(vals), 
-            marker = FRect3D(Vec3f0(0), Vec3f0(7)), # here, if you use less than 10, you will see smaller squares. 
+        meshscatter!(ax1, positions, color = vec(vals),
+            marker = FRect3D(Vec3f0(0), Vec3f0(7)), # here, if you use less than 10, you will see smaller squares.
             colormap = :linear_grey_10_95_c0_n256, colorrange = (-2, 2),
             transparency = false,
             shading= false)
@@ -102,7 +102,7 @@ function front_cover(; resolution=(1200, 2400))
 
         meshscatter!(ax3, vec([(0,i) for i in 0:9]), color = colorSides, shading = false,
             marker = FRect3D(Vec3f0(0), Vec3f0(7)), colormap = :viridis, colorrange = (0,1))
-        
+
         meshscatter!(ax3, vec([(j,i) for i in 0:9, j in 1:4]), shading = false,
             color = vec(vals[end:-1:1,end,:]')[1:40],
             marker = FRect3D(Vec3f0(0), Vec3f0(7)), colormap = :linear_grey_10_95_c0_n256, colorrange = (-2,2))
@@ -123,18 +123,18 @@ function front_cover(; resolution=(1200, 2400))
 
         meshscatter!(ax5, vec([(0,i) for i in 0:9]), color = colorSides, shading = false,
             marker = FRect3D(Vec3f0(0), Vec3f0(7)), colormap = :viridis, colorrange = (0,1))
-        
+
         meshscatter!(ax5, vec([(j,i) for i in 0:9, j in 1:2]), shading = false,
             color = vec(vals[end:-1:1,end,:]')[1:20],
             marker = FRect3D(Vec3f0(0), Vec3f0(7)), colormap = :linear_grey_10_95_c0_n256, colorrange = (-2,2))
 
-        
+
         meshscatter!(ax6, vec(arrTop[1:1,end]), color = colorTop[end:-1:1][1:1], shading = false,
             marker = FRect3D(Vec3f0(0), Vec3f0(7)), colormap = :plasma, colorrange = (0,1))
 
         meshscatter!(ax6, vec([(0,i) for i in 0:9]), color = colorSides, shading = false,
             marker = FRect3D(Vec3f0(0), Vec3f0(7)), colormap = :viridis, colorrange = (0,1))
-        meshscatter!(ax6, vec([(j,i) for i in 0:9, j in 1:1]), shading = false, 
+        meshscatter!(ax6, vec([(j,i) for i in 0:9, j in 1:1]), shading = false,
             color = vec(vals[end:-1:1,end,:]')[1:10],
             marker = FRect3D(Vec3f0(0), Vec3f0(7)), colormap = :linear_grey_10_95_c0_n256, colorrange = (-2,2))
 
@@ -142,7 +142,7 @@ function front_cover(; resolution=(1200, 2400))
 
         Label(fig[1, 1, BottomLeft()], "|>", textsize = 24,
                 rotation = 0pi, padding = (0,3,8,0),font = NOTO_SANS_BOLD)
-        Label(fig[2, 1, BottomLeft()], "|>", textsize = 24, 
+        Label(fig[2, 1, BottomLeft()], "|>", textsize = 24,
             rotation = 0pi, font = NOTO_SANS_BOLD)
         Label(fig[3, 1, BottomLeft()], "|>", textsize = 24,
             rotation = 0pi,padding = (0,3,8,0), font = NOTO_SANS_BOLD)
@@ -171,11 +171,11 @@ function front_cover(; resolution=(1200, 2400))
         xlims!(ax6,-0.5,11)
         ylims!(ax6,-1,11)
 
-        
+
 
         volume!(ax7, collect(1:10),collect(1:10),collect(1:10), rand(10,10,10)) # this just works with GLMakie
         #contour!(ax8, 1:10,1:10,1:10, rand(10,10,10))
-        
+
         x, y, z = peaks()
         x2, y2, z2 = peaks(; n = 15)
         surface!(ax9, x, y, z; colormap = :plasma)
@@ -228,9 +228,9 @@ function front_cover(; resolution=(1200, 2400))
 
 
         axs = [ax1, ax2, ax3, ax4, ax5, ax6, ax7, ax8, ax9,
-            ax10, 
+            ax10,
             ax11,
-            ax12, ax13, 
+            ax12, ax13,
             ax14, ax15, ax16,
             ax62, ax63, ax64, ax65,
             ax52, ax53, ax66]

--- a/src/makie.jl
+++ b/src/makie.jl
@@ -3,9 +3,9 @@ function custom_plot()
     caption = "An example plot with Makie.jl."
     label = missing
     x = 1:10
-    fig, ax, _ = lines(x, x.^2, color = :black, linewidth = 2,linestyle=".-", 
-        label = "x²", figure = (; resolution = (700,450), fontsize = 18, 
-        backgroundcolor = "#D0DFE6FF"), axis = (xlabel = "x", ylabel = "x²", 
+    fig, ax, _ = lines(x, x.^2, color = :black, linewidth = 2,linestyle=".-",
+        label = "x²", figure = (; resolution = (700,450), fontsize = 18,
+        backgroundcolor = "#D0DFE6FF"), axis = (xlabel = "x", ylabel = "x²",
         backgroundcolor = :white))
     axislegend("legend", position = :lt)
     limits!(ax, 0,10,0,100)
@@ -17,9 +17,9 @@ end
 function custom_plot2()
     CairoMakie.activate!() # hide
     x = 1:10
-    lines(x, x.^2, color = :black, linewidth = 2,linestyle=".-", 
-        label = "x²", figure = (; resolution = (700,450), fontsize = 18, 
-        backgroundcolor = "#D0DFE6FF"), axis = (xlabel = "x", ylabel = "x²", 
+    lines(x, x.^2, color = :black, linewidth = 2,linestyle=".-",
+        label = "x²", figure = (; resolution = (700,450), fontsize = 18,
+        backgroundcolor = "#D0DFE6FF"), axis = (xlabel = "x", ylabel = "x²",
         backgroundcolor = :white))
     axislegend("legend", position = :lt)
     limits!( 0,10,0,100)
@@ -51,19 +51,19 @@ function makiejl()
     x = range(0, 10, length=100)
     y = sin.(x)
     p = lines(x, y)
-    caption = "An example plot with Makie.jl." # hide 
-    label = missing # hide 
-    Options(p; caption, label) # hide 
+    caption = "An example plot with Makie.jl." # hide
+    label = missing # hide
+    Options(p; caption, label) # hide
 end
 
 function LaTeX_Strings()
     CairoMakie.activate!() # hide
     x = 0:0.05:4π
-    lines(x,x -> sin(3x)/(cos(x)+2)/x; label=L"\frac{\sin(3x)}{x(\cos(x)+2)}", 
+    lines(x,x -> sin(3x)/(cos(x)+2)/x; label=L"\frac{\sin(3x)}{x(\cos(x)+2)}",
         figure=(;resolution=(600,400), ), axis = (; xlabel = L"x"))
     lines!(x,x-> cos(x)/x; label = L"\cos(x)/x")
     lines!(x,x-> exp(-x); label = L"e^{-x}")
-    limits!(-0.5,13,-0.6,1.05)  
+    limits!(-0.5,13,-0.6,1.05)
     axislegend(L"f(x)")
     current_figure()
 end
@@ -71,7 +71,7 @@ end
 publication_theme()= Theme(
         fontsize = 16,font="CMU Serif",
         Axis = (xlabelsize= 20,xgridstyle=:dash,ygridstyle=:dash,
-            xtickalign = 1, ytickalign=1,yticksize=10, xticksize=10, 
+            xtickalign = 1, ytickalign=1,yticksize=10, xticksize=10,
             xlabelpadding = -5, xlabel = "x", ylabel = "y"),
         Legend = (framecolor = (:black, 0.5), bgcolor = (:white, 0.5)),
         Colorbar = (ticksize=16, tickalign = 1, spinewidth = 0.5)
@@ -94,7 +94,7 @@ function plot_with_legend_and_colorbar()
 end
 
 function multiple_lines()
-    CairoMakie.activate!() # hide 
+    CairoMakie.activate!() # hide
     x = collect(0:10)
 
     fig = Figure(resolution = (600,400), font="CMU Serif")
@@ -124,18 +124,18 @@ function multiple_scatters_and_lines()
     axislegend(L"f(x)"; merge = true,position = :lt,nbanks=2,labelsize=14)
     text!(L"f(x,a) = ax", position = (4,80))
     set_theme!() # reset to default theme
-    fig 
+    fig
 end
 
 function demo_themes()
-    CairoMakie.activate!() # hide 
+    CairoMakie.activate!() # hide
     Random.seed!(123)
     n = 6
     y = cumsum(randn(n, 10), dims = 2)
     labels = ["$i" for i in 1:n]
 
-    fig, _ = series(y; labels = labels, markersize = 10, color=:Set1, 
-        axis = (; xlabel = "time (s)", ylabel = "Amplitude", 
+    fig, _ = series(y; labels = labels, markersize = 10, color=:Set1,
+        axis = (; xlabel = "time (s)", ylabel = "Amplitude",
         title = "Measurements"), figure = (;resolution = (600,300)))
     xh = LinRange(-3,0.5,20)
     yh = LinRange(-3.5,3.5, 20)
@@ -150,15 +150,15 @@ end
 
 function multiple_example_themes()
     CairoMakie.activate!() # hide
-    filenames = ["theme_dark()", "theme_black()", "theme_ggplot2()", # hide 
-        "theme_minimal()", "theme_light()"] # hide 
+    filenames = ["theme_dark()", "theme_black()", "theme_ggplot2()", # hide
+        "theme_minimal()", "theme_light()"] # hide
     function demo_theme()
         Random.seed!(123)
         n = 6
         y = cumsum(randn(n, 10), dims = 2)
         labels = ["$i" for i in 1:n]
-        fig, _ = series(y; labels = labels, markersize = 10, color=:Set1, 
-            axis = (; xlabel = "time (s)", ylabel = "Amplitude", 
+        fig, _ = series(y; labels = labels, markersize = 10, color=:Set1,
+            axis = (; xlabel = "time (s)", ylabel = "Amplitude",
             title = "Measurements"), figure = (;resolution = (600,300)))
         xh = LinRange(-3,0.5,20)
         yh = LinRange(-3.5,3.5, 20)
@@ -169,31 +169,31 @@ function multiple_example_themes()
         current_figure()
     end
 
-    objects = [  
+    objects = [
         with_theme(demo_theme, theme_dark())
         with_theme(demo_theme, theme_black())
         with_theme(demo_theme, theme_ggplot2())
         with_theme(demo_theme, theme_minimal())
         with_theme(demo_theme, theme_light())
-    ] 
-    Options.(objects, filenames) # hide 
+    ]
+    Options.(objects, filenames) # hide
 end
 
 function set_colors_and_cycle()
-    CairoMakie.activate!() # hide 
-    # Epicycloid lines 
+    CairoMakie.activate!() # hide
+    # Epicycloid lines
     x(r,k,θ) = r*(k .+ 1.0).*cos.(θ) .- r*cos.((k .+ 1.0) .* θ)
     y(r,k,θ) = r*(k .+ 1.0).*sin.(θ) .- r*sin.((k .+ 1.0) .* θ)
     θ = LinRange(0,6.2π,1000)
-    
-    axis = (; xlabel = L"x(\theta)", ylabel = L"y(\theta)", 
+
+    axis = (; xlabel = L"x(\theta)", ylabel = L"y(\theta)",
         title = "Epicycloid", aspect= DataAspect())
     figure = (;resolution = (500,400), font= "CMU Serif")
 
-    fig, ax, _ = lines(x(1,1,θ), y(1,1,θ); color = "firebrick1", # string 
+    fig, ax, _ = lines(x(1,1,θ), y(1,1,θ); color = "firebrick1", # string
         label = L"1.0", axis = axis, figure = figure)
     lines!(ax, x(4,2,θ), y(4,2,θ); color = :royalblue1, #symbol
-        label = L"2.0")  
+        label = L"2.0")
     for k in 2.5:0.5:5.5
         lines!(ax, x(2k,k,θ), y(2k,k,θ); label = latexstring("$(k)")) #cycle
     end
@@ -203,10 +203,10 @@ end
 
 function new_cycle_theme()
     # https://nanx.me/ggsci/reference/pal_locuszoom.html
-    my_colors = ["#D43F3AFF", "#EEA236FF", "#5CB85CFF", "#46B8DAFF", 
+    my_colors = ["#D43F3AFF", "#EEA236FF", "#5CB85CFF", "#46B8DAFF",
         "#357EBDFF", "#9632B8FF", "#B8B8B8FF"]
-    cycle = Cycle([:color, :linestyle, :marker], covary = true) # alltogether 
-    my_markers = [:circle, :rect, :utriangle, :dtriangle, :diamond, 
+    cycle = Cycle([:color, :linestyle, :marker], covary = true) # alltogether
+    my_markers = [:circle, :rect, :utriangle, :dtriangle, :diamond,
         :pentagon, :cross, :xcross]
     my_linestyle = [nothing, :dash, :dot, :dashdot, :dashdotdot]
 
@@ -217,7 +217,7 @@ function new_cycle_theme()
         Lines = (cycle = cycle,), Scatter = (cycle = cycle,),
 
         Axis = (xlabelsize= 20,xgridstyle=:dash,ygridstyle=:dash,
-            xtickalign = 1, ytickalign=1,yticksize=10, xticksize=10, 
+            xtickalign = 1, ytickalign=1,yticksize=10, xticksize=10,
             xlabelpadding = -5, xlabel = "x", ylabel = "y"),
         Legend = (framecolor = (:black, 0.5), bgcolor = (:white, 0.5)),
         Colorbar = (ticksize=16, tickalign = 1, spinewidth = 0.5)
@@ -235,7 +235,7 @@ function scatters_and_lines()
     ax = Axis(fig[1,1], xlabel = L"x", ylabel = L"f(x,a)")
     for i in x
         lines!(ax, x, i .* x; label = latexstring("$(i) x"))
-        scatter!(ax, x, i .* x; markersize = 13, strokewidth = 0.25, 
+        scatter!(ax, x, i .* x; markersize = 13, strokewidth = 0.25,
             label = latexstring("$(i) x"))
     end
     hm = heatmap!(xh, yh, h)
@@ -243,7 +243,7 @@ function scatters_and_lines()
     Colorbar(fig[1,2], hm, label = "new default colormap")
     limits!(ax,-0.5,10.5,-5,105)
     colgap!(fig.layout, 5)
-    fig 
+    fig
 end
 
 function first_layout()
@@ -265,20 +265,20 @@ function first_layout_fixed()
     Random.seed!(123)
     x, y, z = randn(6), randn(6), randn(6)
 
-    fig = Figure(figure_padding = (0,3,5,2), resolution = (600,400), 
+    fig = Figure(figure_padding = (0,3,5,2), resolution = (600,400),
         backgroundcolor = :grey90, font="CMU Serif")
-    ax = Axis(fig[1,1], xlabel = L"x", ylabel = L"y", 
+    ax = Axis(fig[1,1], xlabel = L"x", ylabel = L"y",
         title = "Layout example", backgroundcolor = :white)
 
     pltobj = scatter!(ax, x, y; color = z, label = "scatters")
     lines!(ax, x, 1.1y, label = "line")
-    Legend(fig[2, 1:2], ax, "Labels", orientation = :horizontal, 
+    Legend(fig[2, 1:2], ax, "Labels", orientation = :horizontal,
         tellheight = true, titleposition = :left)
     Colorbar(fig[1, 2], pltobj, label = "colorbar")
 
-    # additional aesthetics 
+    # additional aesthetics
     Box(fig[1, 1, Right()], color = (:slateblue1,0.35))
-    Label(fig[1, 1, Right()], "protrusion", textsize = 18, 
+    Label(fig[1, 1, Right()], "protrusion", textsize = 18,
         rotation = pi/2, padding =(3,3,3,3))
     Label(fig[1, 1, TopLeft()], "(a)", textsize = 18, padding = (0,3,8,0))
     colgap!(fig.layout, 5)
@@ -299,10 +299,10 @@ function complex_layout_double_axis()
     ax1 = Axis(fig, xlabel = L"x", ylabel = L"y")
     ax2 = Axis(fig, xlabel = L"x")
     heatmap!(ax1, x, y, z; colorrange = (0,1))
-    series!(ax2, abs.(z[1:4,:]); labels=["lab $i" for i in 1:4], 
+    series!(ax2, abs.(z[1:4,:]); labels=["lab $i" for i in 1:4],
         color = :Set1_4)
     hm = scatter!(10x, y; color = z[1,:],label = "dots",colorrange= (0,1))
-    
+
     hideydecorations!(ax2, ticks = false, grid = false)
     linkyaxes!(ax1, ax2)
     #layout
@@ -310,7 +310,7 @@ function complex_layout_double_axis()
     fig[1,2] = ax2
     Label(fig[1, 1,TopLeft()], "(a)",textsize = 18,padding = (0,6,8,0))
     Label(fig[1, 2,TopLeft()], "(b)",textsize = 18,padding = (0,6,8,0))
-    Colorbar(fig[2,1:2], hm, label = "colorbar", vertical = false, 
+    Colorbar(fig[2,1:2], hm, label = "colorbar", vertical = false,
         flipaxis = false)
     Legend(fig[1,3], ax2, "Legend")
     colgap!(fig.layout, 5)
@@ -326,13 +326,13 @@ function squares_layout()
     fig = Figure(resolution =(500,400),fontsize = 14, font="CMU Serif",
         backgroundcolor = :grey90)
     axs = [Axis(fig[i, j], aspect = DataAspect()) for i in 1:2, j in 1:2]
-    hms = [heatmap!(axs[i,j], randn(10,10), colorrange = (-2,2)) 
+    hms = [heatmap!(axs[i,j], randn(10,10), colorrange = (-2,2))
         for i in 1:2, j in 1:2]
-    
+
     Colorbar(fig[1:2, 3], hms[1], label = "colorbar")
-    [Label(fig[i, j, TopLeft()], "($(letters[i,j]))", textsize = 16, 
+    [Label(fig[i, j, TopLeft()], "($(letters[i,j]))", textsize = 16,
         padding = (-24,0,-16,0)) for i in 1:2, j in 1:2]
-    
+
     colgap!(fig.layout, 5)
     rowgap!(fig.layout, 5)
     fig
@@ -413,12 +413,12 @@ function nested_Grid_Layouts()
     fig
 end
 
-function add_box_inset(fig;left=100,right=250,bottom = 200,top= 300, 
+function add_box_inset(fig;left=100,right=250,bottom = 200,top= 300,
         bgcolor=:grey90)
     # https://discourse.julialang.org/t/makie-inset-axes-and-their-drawing-order/60987 # hide
     inset_box = Axis(fig, bbox = BBox(left, right, bottom, top),
         xticklabelsize = 12, yticklabelsize=12, backgroundcolor = bgcolor)
-    
+
     # bring content upfront
     # bring content upfront
     translate!(inset_box.scene, 0, 0, 10)
@@ -428,10 +428,10 @@ function add_box_inset(fig;left=100,right=250,bottom = 200,top= 300,
     return inset_box
 end
 
-function add_axis_inset(; pos = fig[1,1], halign=0.1, valign=0.5, 
+function add_axis_inset(; pos = fig[1,1], halign=0.1, valign=0.5,
         width = Relative(0.5), height= Relative(0.35), bgcolor=:lightgray)
-    
-    inset_box = Axis(pos, width = width, height = height, 
+
+    inset_box = Axis(pos, width = width, height = height,
         halign=halign, valign=valign, xticklabelsize = 12,yticklabelsize=12,
         backgroundcolor = bgcolor)
 
@@ -462,19 +462,19 @@ function figure_box_inset()
     CairoMakie.activate!() # hide
     fig = Figure(resolution=(600,400))
     ax = Axis(fig[1,1], backgroundcolor = :white)
-    inset_ax1 = add_box_inset(fig; left=100,right=250,bottom = 200,top= 300, 
+    inset_ax1 = add_box_inset(fig; left=100,right=250,bottom = 200,top= 300,
         bgcolor = :grey90)
-    inset_ax2 = add_box_inset(fig; left=500,right=600,bottom = 100,top= 200, 
+    inset_ax2 = add_box_inset(fig; left=500,right=600,bottom = 100,top= 200,
         bgcolor = (:white,.65))
 
     lines!(ax, 1:10)
     lines!(inset_ax1, 1:10)
     scatter!(inset_ax2, 1:10, color = :black)
     fig
-end 
+end
 
 function scatters_in_3D()
-    GLMakie.activate!() # hide 
+    GLMakie.activate!() # hide
     Random.seed!(123)
     xyz = randn(10, 3)
     x, y, z = xyz[:,1], xyz[:,2], xyz[:,3]
@@ -485,8 +485,8 @@ function scatters_in_3D()
 
     scatter!(ax1, x, y, z; markersize = 50)
     meshscatter!(ax2, x, y, z; markersize = 0.25)
-    hm = meshscatter!(ax3, x, y, z; markersize = 0.25, 
-        marker = FRect3D(Vec3f0(0), Vec3f0(1)), color = 1:size(xyz)[2], 
+    hm = meshscatter!(ax3, x, y, z; markersize = 0.25,
+        marker = FRect3D(Vec3f0(0), Vec3f0(1)), color = 1:size(xyz)[2],
         colormap = :plasma, transparency = false)
     cbar = Colorbar(fig, hm, label = "values", height = Relative(0.5))
     fig[1,1] = ax1
@@ -497,7 +497,7 @@ function scatters_in_3D()
 end
 
 function lines_in_3D()
-    GLMakie.activate!() # hide 
+    GLMakie.activate!() # hide
     Random.seed!(123)
     xyz = randn(10, 3)
     x, y, z = xyz[:,1], xyz[:,2], xyz[:,3]
@@ -508,7 +508,7 @@ function lines_in_3D()
 
     lines!(ax1, x, y, z; color = 1:size(xyz)[2], linewidth=3)
     scatterlines!(ax2, x, y, z; markersize = 50)
-    hm = meshscatter!(ax3, x, y, z; markersize = 0.2, 
+    hm = meshscatter!(ax3, x, y, z; markersize = 0.2,
         color = 1:size(xyz)[2])
     lines!(ax3, x, y, z; color = 1:size(xyz)[2])
     cbar = Colorbar(fig, hm; label = "values", height = 15, vertical = false,
@@ -523,14 +523,14 @@ end
 # written by Josef Heinen from GR.jl
 """
     peaks([n=49])
-    
+
 Return a nonlinear function on a grid.  Useful for test cases.
 x, y, z
 """
 function peaks(; n = 49)
     x = LinRange(-3, 3, n)
     y = LinRange(-3, 3, n)
-    a = 3 * (1 .- x').^2 .* exp.(-(x'.^2) .- (y .+ 1).^2) 
+    a = 3 * (1 .- x').^2 .* exp.(-(x'.^2) .- (y .+ 1).^2)
     b = 10 * (x' / 5 .- x'.^3 .- y.^5) .* exp.(-x'.^2 .- y.^2)
     c = 1 / 3 * exp.(-(x' .+ 1).^2 .- y.^2)
     return (x, y, a .- b .- c)
@@ -590,34 +590,34 @@ function mixing_surface_contour3d_contour_and_contourf()
     img = testimage("coffee.png")
     x, y, z = peaks()
     cmap = :Spectral_11
-    
+
     fig = Figure(resolution = (1400,800), fontsize = 26)
-    ax1 = Axis3(fig[1,1]; aspect = (1,1,1), elevation = pi/6, 
-        perspectiveness = 0.5, xzpanelcolor= (:black,0.75), 
-        yzpanelcolor= :black, zgridcolor = :grey70, 
+    ax1 = Axis3(fig[1,1]; aspect = (1,1,1), elevation = pi/6,
+        perspectiveness = 0.5, xzpanelcolor= (:black,0.75),
+        yzpanelcolor= :black, zgridcolor = :grey70,
         ygridcolor = :grey70, xgridcolor = :grey70)
-    ax2 = Axis3(fig[1,3]; aspect = (1,1,1), elevation = pi/6, 
+    ax2 = Axis3(fig[1,3]; aspect = (1,1,1), elevation = pi/6,
         perspectiveness = 0.5)
 
     hm = surface!(ax1, x, y, z; colormap = (cmap, 0.95), shading = true)
-    contour3d!(ax1, x, y, z .+ 0.02; colormap =cmap, 
+    contour3d!(ax1, x, y, z .+ 0.02; colormap =cmap,
         levels = 20, linewidth = 2 )
     xmin, ymin, zmin = minimum(ax1.finallimits[])
     xmax, ymax, zmax = maximum(ax1.finallimits[])
-    contour!(ax1, x, y, z; colormap = cmap, levels = 20, 
+    contour!(ax1, x, y, z; colormap = cmap, levels = 20,
         transformation = (:xy, zmax))
-    contourf!(ax1, x, y, z; colormap = cmap, 
+    contourf!(ax1, x, y, z; colormap = cmap,
         transformation = (:xy, zmin))
     Colorbar(fig[1,2], hm, width = 15, ticksize=15, tickalign = 1,
         height = Relative(0.35))
     # transformations into planes
-    heatmap!(ax2, x, y, z; colormap = :viridis, 
+    heatmap!(ax2, x, y, z; colormap = :viridis,
         transformation = (:yz, 3.5))
-    contourf!(ax2, x, y, z; colormap = :CMRmap, 
+    contourf!(ax2, x, y, z; colormap = :CMRmap,
         transformation = (:xy, -3.5))
-    contourf!(ax2, x, y, z; colormap = :bone_1, 
+    contourf!(ax2, x, y, z; colormap = :bone_1,
         transformation = (:xz, 3.5))
-    image!(ax2, -3..3, -3..2, rotr90(img); 
+    image!(ax2, -3..3, -3..2, rotr90(img);
         transformation = (:xy, 3.8))
     xlims!(ax2, -3.8,3.8)
     ylims!(ax2, -3.8,3.8)
@@ -632,14 +632,14 @@ function arrows_and_streamplot_in_3d()
     ps = [Point3f0(x, y, z) for x in -3:1:3 for y in -3:1:3 for z in -3:1:3]
     ns = map(p -> 0.1*rand() * Vec3f0(p[2], p[3], p[1]), ps)
     lengths = norm.(ns)
-    flowField(x,y,z) = Point(-y + x*(-1+x^2+y^2)^2, x + y*(-1+x^2+y^2)^2, 
+    flowField(x,y,z) = Point(-y + x*(-1+x^2+y^2)^2, x + y*(-1+x^2+y^2)^2,
         z + x*(y-z^2))
 
     fig = Figure(resolution = (1400,800), fontsize = 26)
     ax1 = Axis3(fig[1,1]; aspect = (1,1,1),  perspectiveness = 0.5)
     ax2 = Axis3(fig[1,2]; aspect = (1,1,1),  perspectiveness = 0.5)
     # http://makie.juliaplots.org/stable/plotting_functions/arrows.html # hide
-    arrows!(ax1, ps, ns, color=lengths, linewidth = 0.1, 
+    arrows!(ax1, ps, ns, color=lengths, linewidth = 0.1,
         arrowsize = Vec3f0(0.2, 0.2, 0.3), align = :center)
     streamplot!(ax2, flowField, -4..4, -4..4, -4..4, colormap = :plasma,
         gridsize= (7,7), arrow_size = 0.25,linewidth=1)
@@ -653,7 +653,7 @@ function mesh_volume_contour()
     recmesh = GeometryBasics.mesh(rectMesh)
     sphere = Sphere(Point3f0(0), 1)
     # https://juliageometry.github.io/GeometryBasics.jl/stable/primitives/
-    spheremesh = GeometryBasics.mesh(Tesselation(sphere, 64)) 
+    spheremesh = GeometryBasics.mesh(Tesselation(sphere, 64))
     # uses 64 for tesselation, a smoother sphere
     colors = [rand() for v in recmesh.position]
     # cloud points for volume
@@ -685,7 +685,7 @@ function filled_line_and_linesegments_in_3D()
 
     band!(ax1, lower, upper, color = repeat(norm.(upper), outer=2), colormap = :CMRmap)
     lines!(ax1, upper, color = :black)
-    linesegments!(ax2, cos.(xs), xs, sin.(xs), linewidth = 5, 
+    linesegments!(ax2, cos.(xs), xs, sin.(xs), linewidth = 5,
         color = 1:length(xs), colormap = :plasma)
     fig
 end
@@ -712,34 +712,34 @@ function first_animation()
     end
 end
 
-function grid_spheres_and_rectangle_as_plate()    
+function grid_spheres_and_rectangle_as_plate()
     Random.seed!(123)
     rectMesh = FRect3D(Vec3f0(-1,-1,2.1), Vec3f0(22,11,0.5))
     recmesh = GeometryBasics.mesh(rectMesh)
     colors = [RGBA(rand(4)...) for v in recmesh.position]
-    fig = with_theme(theme_dark()) do 
+    fig = with_theme(theme_dark()) do
         fig = Figure(resolution = (1600,800), fontsize = 26)
-        ax1 = Axis3(fig[1,1]; aspect = (1,1,1),  perspectiveness = 0.5, 
+        ax1 = Axis3(fig[1,1]; aspect = (1,1,1),  perspectiveness = 0.5,
             azimuth= 0.7223275083269882)
         ax2 = Axis3(fig[1,2], aspect=:data, perspectiveness = 0.5,)
 
         for i in 1:2:10, j in 1:2:10, k in 1:2:10
             sphere = Sphere(Point3f0(i,j,k), 1)
-            spheremesh = GeometryBasics.mesh(Tesselation(sphere, 32)) 
-            mesh!(ax1, spheremesh; color = RGBA(i*0.1,j*0.1,k*0.1, 0.75), 
+            spheremesh = GeometryBasics.mesh(Tesselation(sphere, 32))
+            mesh!(ax1, spheremesh; color = RGBA(i*0.1,j*0.1,k*0.1, 0.75),
                 transparency = false, shading = false)
         end
         cbarPal = :plasma
         cmap = get(colorschemes[cbarPal], LinRange(0,1,50))
         for i in 1:2.5:20, j in 1:2.5:10, k in 1:2.5:4
             sphere = Sphere(Point3f0(i,j,k), 1)
-            spheremesh = GeometryBasics.mesh(Tesselation(sphere, 32)) 
+            spheremesh = GeometryBasics.mesh(Tesselation(sphere, 32))
             mesh!(ax2, spheremesh; color = cmap[rand(1:50)],
-            lightposition = Vec3f0(10, 5, 2), 
+            lightposition = Vec3f0(10, 5, 2),
             ambient = Vec3f0(0.95, 0.95, 0.95), backlight = 1f0,
             transparency = false, shading = true)
         end
-        mesh!(recmesh; color= colors, colormap = :rainbow, shading = false, 
+        mesh!(recmesh; color= colors, colormap = :rainbow, shading = false,
             transparency = false)
         #hidedecorations!(ax2)
         fig
@@ -751,7 +751,7 @@ function histogram_or_bars_in_3d()
     x, y, z = peaks(;n = 15)
     δx = (x[2] - x[1])/2
     δy = (y[2] - y[1])/2
-    
+
     cbarPal = :Spectral_11
     ztmp = (z .- minimum(z))./(maximum(z .- minimum(z)))
     cmap = get(colorschemes[cbarPal], ztmp)
@@ -771,7 +771,7 @@ function histogram_or_bars_in_3d()
         rectMesh = FRect3D(Vec3f0(i - δx, j - δy, 0), Vec3f0(2δx, 2δy, z[idx, idy]))
         recmesh = GeometryBasics.mesh(rectMesh)
         lines!(ax2, recmesh; color= (cmap2[idx,idy], ztmp2[idx, idy]))
-        mesh!(ax2, recmesh; color= (cmap2[idx,idy], 0.25), 
+        mesh!(ax2, recmesh; color= (cmap2[idx,idy], 0.25),
             shading = false, transparency = true)
     end
     fig

--- a/src/plots.jl
+++ b/src/plots.jl
@@ -7,10 +7,10 @@ function test_plots_layout()
         label = "sin(x)", leg =:bottomleft, fg_legend = :black,
         bg_legend = nothing)
     plt3 = Plots.plot(x, [sin.(x), cos.(x)], c = :black, leg =:topright,
-        m = (3, [:d :o], [:black :orangered], Plots.stroke(0)), 
+        m = (3, [:d :o], [:black :orangered], Plots.stroke(0)),
         label = ["sin(x)" "cos(x)"], fg_legend = nothing,
         bg_legend = :white, xlab =L"x")
-    plt4 = Plots.plot(x, [sin.(x), cos.(x), -sin.(x), -cos.(x)], lw = 1.5, 
+    plt4 = Plots.plot(x, [sin.(x), cos.(x), -sin.(x), -cos.(x)], lw = 1.5,
         c = [:viridis :plasma :magma :inferno], linez = x,
         colorbar = false, legend =:false, xlab =L"x")
     Plots.plot(plt1, plt2, plt3, plt4, layout = (2,2), legendfont=(8,))

--- a/src/stats.jl
+++ b/src/stats.jl
@@ -1,7 +1,7 @@
 function statistics_graph()
     u = LinRange(0, 2π, 72)
     a, b = 5.0, 2.0
-    # arrow lines 
+    # arrow lines
     x0 = [1, 0] # start point
     x1 = [0.75, -5] # end point
     t0 = [2, 1.0] # starting tangent vector
@@ -11,23 +11,23 @@ function statistics_graph()
     points = [curve(t) for t in T]
     points = hcat(points...)';
     ##
-    fig, ax, = lines(ellipse.(u);  
+    fig, ax, = lines(ellipse.(u);
         figure = (;resolution = (600,400)),
         axis = (; aspect = 1))
     lines!(ellipse.(u; a = 1.5, b = 3, k = -5))
     lines!(points[:,1], points[:,2])
     lines!(-points[:,1], points[:,2])
-    arrows!([points[end-5, 1]], [points[end-5, 2]], 
+    arrows!([points[end-5, 1]], [points[end-5, 2]],
         [-0.1], [0],  arrowsize = 20, lengthscale = 0.2)
-    arrows!([-points[5, 1]], [points[5, 2]], 
+    arrows!([-points[5, 1]], [points[5, 2]],
         [0.1], [0],  arrowsize = 20, lengthscale = 0.2)
-     
-    text!("Data\nGenerating\nProcess", position = (0,0), 
+
+    text!("Data\nGenerating\nProcess", position = (0,0),
         align = (:center, :center), textsize = 24)
-    text!("Observed\nData", position = (0,-5), 
+    text!("Observed\nData", position = (0,-5),
         align = (:center, :center), textsize = 24)
     text!("Inference", position = (-1.2,-2.5), textsize = 24)
-    text!("Probability", position = (0.65,-2.5), textsize = 24, 
+    text!("Probability", position = (0.65,-2.5), textsize = 24,
         align = (:center, :center))
     hidedecorations!(ax)
     hidespines!(ax)
@@ -60,7 +60,7 @@ function plot_central()
     fig = Figure(; resolution=(600, 400))
     ax1 = Axis(fig[1, 1]; limits=((3, 20), nothing))
     ax2 = Axis(fig[2, 1]; limits=((3, 20), nothing))
-    d1, rand_d1 = normal_dist(10, 1) 
+    d1, rand_d1 = normal_dist(10, 1)
     d2, rand_d2 = lognormal_dist(10, 1.5)
     dens(ax1, rand_d1, (:silver, 0.15))
     dens(ax2, rand_d2, (:grey, 0.25))
@@ -139,7 +139,7 @@ function plot_dispersion_std()
     fig = Figure(; resolution=(600, 400))
     ax1 = Axis(fig[1, 1]; limits=((3, 20), nothing))
     ax2 = Axis(fig[2, 1]; limits=((3, 20), nothing))
-    d1, rand_d1 = normal_dist(10, 1) 
+    d1, rand_d1 = normal_dist(10, 1)
     d2, rand_d2 = lognormal_dist(10, 1.5)
     dens(ax1, rand_d1, (:silver, 0.15))
     dens(ax2, rand_d2, (:grey, 0.25))
@@ -201,7 +201,7 @@ function plot_dispersion_mad()
     fig = Figure(; resolution=(600, 400))
     ax1 = Axis(fig[1, 1]; limits=((3, 20), nothing))
     ax2 = Axis(fig[2, 1]; limits=((3, 20), nothing))
-    d1, rand_d1 = normal_dist(10, 1) 
+    d1, rand_d1 = normal_dist(10, 1)
     d2, rand_d2 = lognormal_dist(10, 1.5)
     dens(ax1, rand_d1, (:silver, 0.15))
     dens(ax2, rand_d2, (:grey, 0.25))
@@ -262,7 +262,7 @@ function plot_dispersion_iqr()
     fig = Figure(; resolution=(600, 400))
     ax1 = Axis(fig[1, 1]; limits=((3, 20), nothing))
     ax2 = Axis(fig[2, 1]; limits=((3, 20), nothing))
-    d1, rand_d1 = normal_dist(10, 1) 
+    d1, rand_d1 = normal_dist(10, 1)
     d2, rand_d2 = lognormal_dist(10, 1.5)
     dens(ax1, rand_d1, (:silver, 0.15))
     dens(ax2, rand_d2, (:grey, 0.25))
@@ -400,7 +400,7 @@ function plot_normal_lognormal()
     CairoMakie.activate!() # hide
     fig = Figure(; resolution=(600, 400))
     ax = Axis(fig[1, 1]; limits=((3, 20), nothing))
-    _, rand_d1 = normal_dist(10, 1) 
+    _, rand_d1 = normal_dist(10, 1)
     _, rand_d2 = lognormal_dist(10, 1.3)
     density!(ax, rand_d1; color=(:dodgerblue, 0.15), strokewidth=1.5, strokecolor=(:black, 0.5), label="normal")
     density!(ax, rand_d2; color=(:red, 0.15), strokewidth=1.5, strokecolor=(:black, 0.5), label="non-normal")


### PR DESCRIPTION
Add a simple trailing whitespace check.

For some reason, CI in #124 is broken. So, that's why this is a new PR for the same thing.

To locally remove all whitespace, use:

```
$ julia --project=format

julia> using FormatJDS

julia> remove_trailing_whitespace()

```

EDIT: I've tried only starting `CI` if `Format` succeeds to save some build minutes. Unfortunately, that should be done via `workflow_run` and that appears to be a bit weird. There even exist Actions to workaround missing functionality (for example, https://github.com/ahmadnassri/action-workflow-run-wait).