### PR TITLE
Show cover on front page

### DIFF
--- a/contents/index.md
+++ b/contents/index.md
@@ -36,7 +36,7 @@ Of course, data science is about more things than just tables, basic statistics 
 We want to cover more topics, but we have scheduled them for the second edition of the book.
 For now, the planned topics for the second edition are:
 
-- More statistics (probably, descriptive statistics, `Distributions.jl`)
+- More statistics
 - Plotting via `AlgebraOfGraphics.jl`.
 - Machine learning (probably, `MLJ.jl` and `Flux.jl`)
 - Bayesian statistics (`Turing.jl`)
@@ -61,20 +61,14 @@ Or in BibTeX format:
 }
 ```
 
-
-```{=comment}
-To generate these images, run `write_front_cover()`.
-```
-
-```{=comment}
 ### Front Cover {-}
 
-<center>
-    <a href="/im/front_cover.png">
-        <image src="/im/front_cover_thumbnail.png" alt="Book front cover">
-    </a><br/>
-
-    <i>Click to see the full size version.</i>
-</center>
+```jl
+let
+    fig = front_cover()
+    # Use lazy loading to keep homepage speed high.
+    link_attributes = "loading=\"lazy\" width=80%"
+    Options(fig; caption=nothing, label=nothing, link_attributes)
+end
 ```
 

--- a/src/JDS.jl
+++ b/src/JDS.jl
@@ -113,7 +113,6 @@ This method is called during CI.
 function build()
     println("Building JDS")
     gen(; fail_on_error=true)
-    write_front_cover()
     extra_head = """
     <script src="https://cdn.usefathom.com/script.js" data-site="EEJXHKTE" defer></script>
     """

--- a/src/front-cover.jl
+++ b/src/front-cover.jl
@@ -33,11 +33,11 @@ colorSides =  vec(valsSides[end,:])
 
 
 """
-    front_cover(; resolution=(1200, 2400))
+    front_cover()
 
 Return the Julia Data Science book front cover.
 """
-function front_cover(; resolution=(1200, 2400))
+function front_cover()
     CairoMakie.activate!()
     with_theme(theme_black()) do
         #589.44, 884.16
@@ -242,50 +242,4 @@ function front_cover(; resolution=(1200, 2400))
         #display(fig)
         fig
     end
-end
-
-"""
-    compress_image(from::String, to::String)
-
-Read image at `from` and write compressed image to `to`.
-Based on suggestions from <https://stackoverflow.com/questions/7261855>.
-"""
-function compress_image(from::String, to::String; extra_args=nothing)
-    args = [
-        "-sampling-factor",
-        "4:2:0",
-        "-strip",
-        "-quality",
-        "85",
-        "-interlace",
-        "JPEG",
-        # Don't use this to avoid change in appearance.
-        # "-colorspace",
-        # "RGB"
-        extra_args...
-    ]
-    run(`convert $from $args $to`)
-end
-
-"""
-    write_front_cover()
-
-Write small front cover thumbnail and the full size front cover.
-This smaller image is useful for reducing frontpage loading time.
-"""
-function write_front_cover()
-    fig = front_cover()
-    opts = Options(fig; filename="front_cover")
-    # Writes PNG image to file.
-    convert_output(nothing, nothing, opts)
-    full = joinpath("_build", "im", "front_cover.png")
-
-    thumbnail = joinpath("_build", "im", "front_cover_thumbnail.png")
-    extra_args = [
-        "-resize",
-        "250x500"
-    ]
-    compress_image(full, thumbnail; extra_args)
-
-    return nothing
 end


### PR DESCRIPTION
As mentioned in b5dcea4befb5a2910f8b2eb8772ca0ef629aeb90, 506e24078ea60e95b13a030ee6f5feabbba05523 and #123. This PR shows the cover on the front page. The image isn't centered unfortunately. It's a bug in Books.jl: https://github.com/rikhuijzer/Books.jl/issues/217. I'll fix that.

This is the full size image. To avoid the 1.4 MB image to slow down the homepage loading, I've set `loading="lazy"` (more info at https://developer.mozilla.org/en-US/docs/Web/Performance/Lazy_loading).

<br>
<br>

![image](https://user-images.githubusercontent.com/20724914/134330413-db20a2e6-c5fc-43fa-a8fd-bbfe56dc0fea.png)

