### PR TITLE
Change wording to be less strong

### DIFF
--- a/contents/dataframes_performance.md
+++ b/contents/dataframes_performance.md
@@ -130,8 +130,7 @@ We need to wrap anything that `CSV.File` returns in a `DataFrame` constructor fu
 df = DataFrame(CSV.File("file.csv"))
 ```
 
-Or, in a more preferred idiomatic syntax with the pipe `|>` operator:
-
+Or, with the pipe `|>` operator:
 
 ```julia
 df = CSV.File("file.csv") |> DataFrame


### PR DESCRIPTION
I would say that it's up to the reader to decide when to use the pipe and when not. There are cases where the pipe indeed makes more sense for `CSV.File`, but there are also cases when not. Therefore, calling it "more preferred idiomatic" is a bit too strong.