### PR TITLE
Add full cover

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -30,7 +30,6 @@ Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 StatsPlots = "f3b207a7-027a-5e70-b257-86293d7955fd"
-Tectonic = "9ac5f52a-99c6-489f-af81-462ef484790f"
 TestImages = "5e47fb64-e119-507b-a336-dd2b206d9990"
 XLSX = "fdbf4ff8-1666-58a4-91e7-1b58723a45e0"
 

--- a/Project.toml
+++ b/Project.toml
@@ -30,6 +30,7 @@ Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 StatsPlots = "f3b207a7-027a-5e70-b257-86293d7955fd"
+Tectonic = "9ac5f52a-99c6-489f-af81-462ef484790f"
 TestImages = "5e47fb64-e119-507b-a336-dd2b206d9990"
 XLSX = "fdbf4ff8-1666-58a4-91e7-1b58723a45e0"
 

--- a/contents/index.md
+++ b/contents/index.md
@@ -57,7 +57,7 @@ For now, the planned topics for the second edition are:
 To cite the content, please use:
 
 ```plaintext
-Storopoli, Huijzer and Alonso (2021). Julia Data Science. https://juliadatascience.io.
+Storopoli, Huijzer and Alonso (2021). Julia Data Science. https://juliadatascience.io. ISBN: 9798489859165.
 ```
 
 Or in BibTeX format:
@@ -67,7 +67,8 @@ Or in BibTeX format:
   title = {Julia Data Science},
   author = {Jose Storopoli and Rik Huijzer and Lazaro Alonso},
   url = {https://juliadatascience.io},
-  year = {2021}
+  year = {2021},
+  isbn = {9798489859165}
 }
 ```
 

--- a/contents/index.md
+++ b/contents/index.md
@@ -72,9 +72,7 @@ Or in BibTeX format:
 }
 ```
 
-### Cover {-}
-
-The front cover is depicted below and the full cover is available as `jl cover()`.
+### Front Cover {-}
 
 ```jl
 let

--- a/contents/index.md
+++ b/contents/index.md
@@ -71,13 +71,15 @@ Or in BibTeX format:
 }
 ```
 
-### Front Cover {-}
+### Cover {-}
+
+The front cover is depicted below and the full cover is available as `jl cover()`.
 
 ```jl
 let
     fig = front_cover()
     # Use lazy loading to keep homepage speed high.
-    link_attributes = "loading=\"lazy\" width=80%"
+    link_attributes = """loading="lazy" width=80%"""
     Options(fig; caption=nothing, label=nothing, link_attributes)
 end
 ```

--- a/contents/preface.md
+++ b/contents/preface.md
@@ -5,7 +5,7 @@ Some languages are very quick, but verbose.
 Other languages are very easy to write in, but slow. This is known as the `two-language` problem and Julia aims at circumventing this problem.
 Even though all three of us come from different fields, we all found the Julia language more effective for our research than languages that we've used before.
 We discuss some of our arguments in @sec:why_julia.
-Compared to other languages, Julia is one of the newest languages around.
+However, compared to other languages, Julia is one of the newest languages around.
 This means that the ecosystem around the language is sometimes difficult to navigate through.
 It's difficult to figure out where to start and how all the different packages fit together.
 That is why we decided to create this book!

--- a/src/JDS.jl
+++ b/src/JDS.jl
@@ -63,7 +63,6 @@ using Statistics
 using StatsBase:
     mad,
     mode
-using Tectonic: tectonic
 using TestImages
 using XLSX:
     eachtablerow,

--- a/src/JDS.jl
+++ b/src/JDS.jl
@@ -63,6 +63,7 @@ using Statistics
 using StatsBase:
     mad,
     mode
+using Tectonic: tectonic
 using TestImages
 using XLSX:
     eachtablerow,
@@ -81,6 +82,7 @@ include("makie.jl")
 include("stats.jl")
 include("bezier.jl")
 include("front-cover.jl")
+include("cover.jl")
 
 # Showcode additions.
 export sce, scsob, trim_last_n_lines, plainblock
@@ -108,5 +110,6 @@ export anscombe_quartet, plot_anscombe
 
 # Book cover.
 export compress_image, front_cover, write_front_cover
+export cover
 
 end # module

--- a/src/JDS.jl
+++ b/src/JDS.jl
@@ -108,7 +108,6 @@ export calculate_pdf
 export anscombe_quartet, plot_anscombe
 
 # Book cover.
-export compress_image, front_cover, write_front_cover
-export cover
+export front_cover
 
 end # module

--- a/src/JDS.jl
+++ b/src/JDS.jl
@@ -82,7 +82,6 @@ include("makie.jl")
 include("stats.jl")
 include("bezier.jl")
 include("front-cover.jl")
-include("cover.jl")
 
 # Showcode additions.
 export sce, scsob, trim_last_n_lines, plainblock

--- a/src/cover.jl
+++ b/src/cover.jl
@@ -72,6 +72,10 @@ function cover()
     tex_path = joinpath(dir, "cover.tex")
     write(tex_path, tex)
 
+    favicon_from = joinpath(pkgdir(JDS), "pandoc", "favicon.png")
+    favicon_to = joinpath(pkgdir(JDS), BUILD_DIR, "favicon.png")
+    cp(favicon_from, favicon_to; force=true)
+
     tectonic() do bin
         cd(dir) do
             run(`$bin --print $tex_path`)

--- a/src/cover.jl
+++ b/src/cover.jl
@@ -27,7 +27,6 @@ function cover()
         ]{geometry}
 
         \usepackage{graphicx}
-        \graphicspath{{im/}}
 
         \begin{document}
         \begin{bookcover}
@@ -35,19 +34,35 @@ function cover()
 
         \bookcovercomponent{center}{spine}{
             \rotatebox[origin=c]{-90}{
+                \large\textcolor{white}{Storopoli, Huijzer \& Alonso}
+                \hspace*{7in}
                 \Huge\bfseries\textcolor{white}{Julia Data Science}
             }
+            \vspace*{1in}
+            \includegraphics[height=0.8\textwidth]{favicon.png}
         }
 
         \bookcovercomponent{normal}{back}{
-            \vfill
-            \textcolor{white}{foo}
+            \vspace*{1in}
+            \hspace*{0.6in}
+            \parbox[c]{0.85\textwidth}{\Large\textcolor{white}{
+        There are many programming languages and each and every one of them has its strengths and weaknesses.
+        Some languages are very quick, but verbose.
+        Other languages are very easy to write in, but slow.
+        This is known as the `two-language` problem and the Julia programming language aims at circumventing this problem.
+        Even though all three of us come from different fields, we all found the Julia language more effective for our research than languages that we've used before.
+        However, compared to other languages, Julia is one of the newest languages around.
+        This means that the ecosystem around the language is sometimes difficult to navigate through.
+        It's difficult to figure out where to start and how all the different packages fit together.
+        That is why we decided to create this book!
+        We wanted to make it easier for researchers, and especially our colleagues, to start using this awesome language.
+            }}
         }
 
         \bookcovercomponent{normal}{front}{
             \vspace*{-0.5in}
             \hspace*{0.5in} % At minimum hinge size.
-            \includegraphics[width=0.97\textwidth]{front_cover_.png}
+            \includegraphics[width=0.97\textwidth]{./im/front_cover_.png}
         }
 
 

--- a/src/cover.jl
+++ b/src/cover.jl
@@ -13,6 +13,15 @@ function cover()
     filename = "cover.pdf"
     dir = joinpath(pkgdir(JDS), BUILD_DIR)
     pdf_path = joinpath(dir, filename)
+
+    favicon_from = joinpath(pkgdir(JDS), "pandoc", "favicon.png")
+    favicon_to = joinpath(pkgdir(JDS), BUILD_DIR, "favicon.png")
+    cp(favicon_from, favicon_to; force=true)
+
+    fig = front_cover()
+    png_path = joinpath(dir, "front_cover.png")
+    FileIO.save(png_path, fig; px_per_unit=1)
+
     # See https://kdp.amazon.com/cover-calculator for details.
     tex = raw"""
         \documentclass[
@@ -39,7 +48,8 @@ function cover()
                 \Huge\bfseries\textcolor{white}{Julia Data Science}
             }
             \vspace*{1in}
-            \includegraphics[height=0.8\textwidth]{favicon.png}
+            % Should be 0.75 or less. Checked with the Amazon Print Previewer.
+            \includegraphics[height=0.75\textwidth]{favicon.png}
         }
 
         \bookcovercomponent{normal}{back}{
@@ -62,22 +72,14 @@ function cover()
         \bookcovercomponent{normal}{front}{
             \vspace*{-0.5in}
             \hspace*{0.5in} % At minimum hinge size.
-            \includegraphics[width=0.97\textwidth]{./im/front_cover_.png}
+            \includegraphics[width=0.97\textwidth]{front_cover.png}
         }
-
 
         \end{bookcover}
         \end{document}
         """
     tex_path = joinpath(dir, "cover.tex")
     write(tex_path, tex)
-
-    favicon_from = joinpath(pkgdir(JDS), "pandoc", "favicon.png")
-    favicon_to = joinpath(pkgdir(JDS), BUILD_DIR, "favicon.png")
-    cp(favicon_from, favicon_to; force=true)
-
-    # To generate the front cover image.
-    gen("index")
 
     tectonic() do bin
         cd(dir) do

--- a/src/cover.jl
+++ b/src/cover.jl
@@ -76,6 +76,9 @@ function cover()
     favicon_to = joinpath(pkgdir(JDS), BUILD_DIR, "favicon.png")
     cp(favicon_from, favicon_to; force=true)
 
+    # To generate the front cover image.
+    gen("index")
+
     tectonic() do bin
         cd(dir) do
             run(`$bin --print $tex_path`)

--- a/src/cover.jl
+++ b/src/cover.jl
@@ -4,5 +4,64 @@
 Return the book cover.
 """
 function cover()
-    return nothing
+    width = 2 * 2016
+    height = (10/7) * width # Ratio 7 * 10 inch.
+    fig = Figure(; resolution=(width, height))
+    # fig[1, 2] = Scene(front_cover())
+    # return fig
+
+    filename = "cover.pdf"
+    dir = joinpath(pkgdir(JDS), BUILD_DIR)
+    pdf_path = joinpath(dir, filename)
+    # See https://kdp.amazon.com/cover-calculator for details.
+    tex = raw"""
+        \documentclass[
+        coverwidth=11.417in,
+        coverheight=16.233in,
+        spinewidth=0.685in,
+        bleedwidth=0.591in,
+        12pt
+        ]{bookcover}
+
+        \usepackage[
+        ]{geometry}
+
+        \usepackage{graphicx}
+        \graphicspath{{im/}}
+
+        \begin{document}
+        \begin{bookcover}
+        \bookcovercomponent{color}{bg whole}{black}
+
+        \bookcovercomponent{center}{spine}{
+            \rotatebox[origin=c]{-90}{
+                \Huge\bfseries\textcolor{white}{Julia Data Science}
+            }
+        }
+
+        \bookcovercomponent{normal}{back}{
+            \vfill
+            \textcolor{white}{foo}
+        }
+
+        \bookcovercomponent{normal}{front}{
+            \vspace*{-0.5in}
+            \hspace*{0.5in} % At minimum hinge size.
+            \includegraphics[width=0.97\textwidth]{front_cover_.png}
+        }
+
+
+        \end{bookcover}
+        \end{document}
+        """
+    tex_path = joinpath(dir, "cover.tex")
+    write(tex_path, tex)
+
+    tectonic() do bin
+        cd(dir) do
+            run(`$bin --print $tex_path`)
+        end
+    end
+
+    return "[PDF](/$(filename))"
 end

--- a/src/front-cover.jl
+++ b/src/front-cover.jl
@@ -174,11 +174,13 @@ function front_cover()
             tellheight = false, halign = :left)
         Label(fig[1, 3:5], "\n\n\n\nData Science", textsize=126,
             tellheight = false, halign = :left)
-        Label(fig[2, 4:5], "Jose Storopoli", textsize=60,
+        vspace = "\n\n"
+        hspace = "         "
+        Label(fig[2, 3:5], "$(vspace)$(hspace)Jose Storopoli", textsize=80,
             tellheight = false, halign = :left)
-        Label(fig[2, 4:5], "\n\nRik Huijzer", textsize=60,
+        Label(fig[2, 3:5], "$(vspace)\n\n$(hspace)Rik Huijzer", textsize=80,
             tellheight = false, halign = :left)
-        Label(fig[2, 4:5], "\n\n\n\nLazaro Alonso", textsize=60,
+        Label(fig[2, 3:5], "$(vspace)\n\n\n\n$(hspace)Lazaro Alonso", textsize=80,
             tellheight = false, halign = :left)
 
         #     textsize = 60, tellheight = false)

--- a/src/front-cover.jl
+++ b/src/front-cover.jl
@@ -40,12 +40,15 @@ colorSides =  vec(valsSides[end,:])
 Return the Julia Data Science book front cover.
 """
 function front_cover()
-    CairoMakie.activate!() # probably it will be good to have to version, one black and one white
+    # Probably it will be good to have two versions, one black and one white.
+    CairoMakie.activate!()
     with_theme(theme_black(); Axis = (; ygridcolor = :grey70, xgridcolor = :grey70,
         xgridstyle=:dashdot, ygridstyle=:dashdot),
         Axis3 = (; xgridcolor = :grey70, ygridcolor = :grey70, zgridcolor = :grey70)) do
-        # Figure
-        fig = Figure(resolution=(2016,2760)) # new ratio 7x10 in
+
+        width = 2016
+        height = (10/7) * width # Ratio 7 * 10 inch.
+        fig = Figure(resolution=(width, height))
         # Colors
         colors = ColorSchemes.Set1_6
         #colors = Makie.wong_colors()
@@ -182,8 +185,6 @@ function front_cover()
         [hidespines!(ax) for ax in axs]
         rowgap!(fig.layout, 0)
         colgap!(fig.layout, 0)
-        #save("front_cover.png", fig) # no need to compress image
-        #display(fig)
         return fig
     end
 end

--- a/src/front-cover.jl
+++ b/src/front-cover.jl
@@ -169,16 +169,18 @@ function front_cover()
               rotation = 0π, padding = (5,5,0,0), font = NOTO_SANS_BOLD)
         Label(fig[4,4, Right()], "|>", textsize = pipisize,
               rotation = 0π, padding = (5,5,0,0), font = NOTO_SANS_BOLD)
-        # Title and Text Stuff
-        Label(fig[0, 2:5, Bottom()], "Julia\nData Science", textsize = 120,
+
+        Label(fig[1, 3:5], "Julia", textsize=394,
             tellheight = false, halign = :left)
-        Label(fig[3, 4:end], "Jose Storopoli", #color = JuliaColors.purple,
-            textsize = 60, tellheight = false, halign = :left)
-        Label(fig[3, 4:end], "\n\nRik Huijzer", #color = JuliaColors.red,
-            textsize = 60, tellheight = false, halign = :left)
-        Label(fig[3, 4:end], "\n\n\n\nLazaro Alonso", #color = JuliaColors.green,
-            textsize = 60, tellheight = false, halign = :left)
-        # Label(fig[3, 3:end], "Jose Storopoli, Rik Huijzer\n and Lazaro Alonso",
+        Label(fig[1, 3:5], "\n\n\n\nData Science", textsize=126,
+            tellheight = false, halign = :left)
+        Label(fig[2, 4:5], "Jose Storopoli", textsize=60,
+            tellheight = false, halign = :left)
+        Label(fig[2, 4:5], "\n\nRik Huijzer", textsize=60,
+            tellheight = false, halign = :left)
+        Label(fig[2, 4:5], "\n\n\n\nLazaro Alonso", textsize=60,
+            tellheight = false, halign = :left)
+
         #     textsize = 60, tellheight = false)
         # Final Axis and Figure touches
         [hidedecorations!(ax; grid = false) for ax in axs]


### PR DESCRIPTION
This PR add code to generate the full cover. See https://github.com/JuliaDataScience/JuliaDataScience/issues/17#issuecomment-927185934 for more information about the dimensions.

I don't consider the cover done and perfect now. It is meant as a place where we can start discussing the appearance.

# Preview

![image](https://user-images.githubusercontent.com/20724914/135890987-ef8192cc-46e4-4486-902d-170d2389c08c.png)

**EDIT:** This wasn't working in Amazon. It was turned into 

![image](https://user-images.githubusercontent.com/20724914/135913902-f379d4d8-1262-4686-9fa4-a77bfae6be36.png)

So, instead using the Amazon cover editor:

![image](https://user-images.githubusercontent.com/20724914/135913876-c8481978-aca9-4b51-97c9-91eb1fadb87c.png)

which is turned into

![image](https://user-images.githubusercontent.com/20724914/135914109-53dd64aa-3559-44fd-aaa0-b608c65b3116.png)