### PR TITLE
Mention edition

### DIFF
--- a/metadata.yml
+++ b/metadata.yml
@@ -33,8 +33,10 @@ titlepage-top: >
   Germany\\
   \end{tabular}
 
-titlepage-bottom: >
+titlepage-bottom: |
+  First edition published 2021
+
   \url{https://juliadatascience.io}
 
-dedication: "This book is dedicated to our families."
+  ISBN: 9798489859165
 ---


### PR DESCRIPTION
Updates the title page to look like the image below. The reason is to fix Google Scholar, because Scholar currently doesn't show the year. Also, I suggest to change the version name from *version 1* to *first edition* since the latter is the convention for books. (If suggestion is accepted, then this needs to be changed in the GitHub issues as well.)

I also suggest to remove the dedication. I proposed to add it a few weeks back, but don't like it anymore. My girlfriend thought it looked stupid :stuck_out_tongue: 

![image](https://user-images.githubusercontent.com/20724914/136691484-f4112818-789a-4f70-baf9-66b6b7e3576e.png)
