### PR TITLE
Add `using LaTeXStrings`

### DIFF
--- a/contents/data_vis_makie_latex.md
+++ b/contents/data_vis_makie_latex.md
@@ -25,11 +25,7 @@ s = """
 sco(s)
 ```
 
-A more involved example will be one with some equation as `text` and increasing legend numbering for curves in a plot.
-
-```
-using LaTeXStrings
-```
+A more involved example will be one with some equation as `text` and increasing legend numbering for curves in a plot:
 
 ```jl
 @sco JDS.multiple_lines()


### PR DESCRIPTION
I was trying to use LaTeX equations in Makie with our book, but it wasn't completely clear that it is required to first load `LaTeXStrings.jl`.