### PR TITLE
Remove Statistics Chapter and Appendix Project Management Section

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -24,12 +24,12 @@
     "data_vis_makie_colors",
     "data_vis_makie_layouts",
     "data_vis_makie_glmakie",
-    "stats",
-    "stats_distributions",
-    "stats_vis",
+    #"stats",
+    #"stats_distributions",
+    #"stats_vis",
     "appendix",
     "notation",
-    "project_management",
+    #"project_management",
     "references"
   ]
   port = 8006

--- a/contents/appendix.md
+++ b/contents/appendix.md
@@ -1,5 +1,7 @@
 # Appendix {#sec:appendix}
 
+## Packages Versions {#sec:appendix_pkg}
+
 This book is built with Julia `jl string(VERSION)` and the following packages:
 
 ```jl

--- a/contents/data_vis_makie_attributes.md
+++ b/contents/data_vis_makie_attributes.md
@@ -108,7 +108,7 @@ For more on `themes` please go to @sec:themes.
 Before moving on into the next section, it's worthwhile to see an example where an `array` of attributes are passed at once to a plotting function.
 For this example, we will use the `scatter` plotting function to do a bubble plot.
 
-The data for this could be an `array` with 100 rows and 3 columns, here we generated these at random from a normal distribution, @sec:stats_dist_normal.
+The data for this could be an `array` with 100 rows and 3 columns, here we generated these at random from a normal distribution.
 Where the first column could be the positions in the `x` axis, the second one the positions in `y` and the third one an intrinsic associated value for each point.
 The later could be represented in a plot by a different `color` or with a different marker size. In a bubble plot we can do both.
 

--- a/contents/why_julia.md
+++ b/contents/why_julia.md
@@ -67,7 +67,6 @@ We have some examples in @sec:multiple_dispatch.
 Unlike traditional package managers, which install and manage a single global set of packages, Julia's package manager is designed around "environments":
 independent sets of packages that can be local to an individual project or shared between projects.
 Each project maintains its own independent set of package versions.
-We'll talk more about how to manage your projects and packages in the Appendix [-@sec:project_management].
 
 If we got your attention by exposing somewhat familiar or plausible situations, you might be interested to learn more about this newcomer called Julia.
 


### PR DESCRIPTION
This PR removes the Statistics Chapter and Project Management Appendix Section

I think it should not be included in 1.0 and 1st edition. I had a long thought about this.
I just commented it out of the `config.toml` and also removed the references on other sections.
We can always include it back in future versions.
I think the book should be `DataFrames.jl` and `Makie.jl` for now.

I also added a H2 header to the Pkg versions to be included and better displayed in the table of contents.