### PR TITLE
Fix Shell Files in .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,6 @@
 # LaTeX Stuff
 pandoc/references.bib linguist-generated
+*.tex linguist-generated
 
 # Site
 _build/* text


### PR DESCRIPTION
This is annoying:
![image](https://user-images.githubusercontent.com/43353831/138339467-a608789c-5898-40f5-8a7c-00999d049a8a.png)
