### PR TITLE
Update julia_basics.md fix typo in Downloads

### DIFF
--- a/contents/julia_basics.md
+++ b/contents/julia_basics.md
@@ -2339,7 +2339,7 @@ If you don't specify a second argument, Julia will, by default, create a tempora
 Let's load the `download` method:
 
 ```julia
-using Download: download
+using Downloads: download
 ```
 
 For example, let's download our [`JuliaDataScience` GitHub repository](https://github.com/JuliaDataScience/JuliaDataScience) `Project.toml` file.


### PR DESCRIPTION
The pkg name is `Downloads` not `Download`.