### PR TITLE
improve PR #214

### DIFF
--- a/contents/julia_basics.md
+++ b/contents/julia_basics.md
@@ -818,20 +818,20 @@ scob(s)
 ```
 
 
-1. `occursin`, `startswith` and `endswith`: A conditional (returns either `true` or `false`) if the first argument is a:
-    * **substring** of the second argument
+1. `contains`, `startswith` and `endswith`: A conditional (returns either `true` or `false`) if the second argument is a:
+    * **substring** of the first argument
 
        ```jl
-       scob("""occursin("Julia", julia_string)""")
+       scob("""contains(julia_string, "Julia")""")
        ```
 
-    * **prefix** of the second argument
+    * **prefix** of the first argument
 
        ```jl
        scob("""startswith(julia_string, "Julia")""")
        ```
 
-    * **suffix** of the second argument
+    * **suffix** of the first argument
 
        ```jl
        scob("""endswith(julia_string, "Julia")""")


### PR DESCRIPTION
while the syntax of the commands `startswith` and `endswith` was corrected in PR #214, the surrounding text wasn't adapted to that change as well. This is done in this PR. To simplify that, also the command `occursin` was changed to `contains` which has the same syntax as `startswith` and `endwith` (and internally calls `occursin`).