### PR TITLE
Fix additional subfolder created by CI.yml in Portuguese Version

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -24,7 +24,7 @@ jobs:
         run: |
           git clone --branch=gh-pages https://github.com/JuliaDataScience/JuliaDataScience ~/jds
           mkdir -p _build/pt
-          cp -r ~/jds/pt _build/pt
+          cp -r ~/jds/pt _build/
 
       - uses: julia-actions/cache@v1
 


### PR DESCRIPTION
```bash
cp -r ~/jds/pt _build/pt
```

copies the folder `pt/` to `_build/pt/pt`

We need to have just:

```bash
cp -r ~/jds/pt _build
```