### PR TITLE
Fix `scob` when Float32 is explictly demonstrated

### DIFF
--- a/contents/julia_basics.md
+++ b/contents/julia_basics.md
@@ -394,7 +394,11 @@ Now, it works as expected with any float type:
 ```jl
 s = """
     x_32 = Float32(1.1)
-    round_number(x_32)
+    x_32 = round_number(x_32)
+    io = IOBuffer(); # hide
+    show(io, r) # hide
+    x_32 = String(take!(io)) # hide
+    x_32
     """
 scob(s)
 ```

--- a/contents/julia_basics.md
+++ b/contents/julia_basics.md
@@ -394,13 +394,9 @@ Now, it works as expected with any float type:
 ```jl
 s = """
     x_32 = Float32(1.1)
-    x_32 = round_number(x_32)
-    io = IOBuffer(); # hide
-    show(io, r) # hide
-    x_32 = String(take!(io)) # hide
-    x_32
+    round_number(x_32)
     """
-scob(s)
+sco(s; process=(x -> sprint(show, x)), post=output_block)
 ```
 
 > **_NOTE:_**


### PR DESCRIPTION
This closes #254.