### PR TITLE
Switch to Books v2

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -23,4 +23,4 @@ ENV DISPLAY=:0
 ENV JULIA_NUM_THREADS=2
 
 ENTRYPOINT ["/bin/sh", "-c", "/usr/bin/xvfb-run -s '-screen 0 1024x768x24' $@", ""]
-CMD ["julia"]
+CMD ["julia", "--project"]

--- a/.devcontainer/run.sh
+++ b/.devcontainer/run.sh
@@ -12,6 +12,7 @@ fi
 
 if [ "$1" == "SERVE" ]; then
   docker run -it --rm \
+    -it \
     --env GKSwstype=nul \
     -p 8006:8006 \
     -v "$HOME/.julia-docker":"/root/.julia" \

--- a/.devcontainer/run.sh
+++ b/.devcontainer/run.sh
@@ -12,7 +12,6 @@ fi
 
 if [ "$1" == "SERVE" ]; then
   docker run -it --rm \
-    -it \
     --env GKSwstype=nul \
     -p 8006:8006 \
     -v "$HOME/.julia-docker":"/root/.julia" \

--- a/.devcontainer/run.sh
+++ b/.devcontainer/run.sh
@@ -13,12 +13,14 @@ fi
 if [ "$1" == "SERVE" ]; then
   docker run -it --rm \
     --env GKSwstype=nul \
+    --cpus 2 \
     -p 8006:8006 \
     -v "$HOME/.julia-docker":"/root/.julia" \
     -v "$PWD":/app -w /app jds
 else
   docker run -it --rm \
     --env GKSwstype=nul \
+    --cpus 2 \
     -v "$HOME/.julia-docker":"/root/.julia" \
     -v "$PWD":/app -w /app jds
 fi

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: julia-actions/setup-julia@v1
         with:
-          version: "1.7"
+          version: "1"
 
       - name: Copy over the Portuguese output
         shell: bash
@@ -31,10 +31,6 @@ jobs:
 
       - name: Install GLMakie dependencies
         run: sudo apt-get update && sudo apt-get install -y xorg-dev imagemagick mesa-utils xvfb libgl1 freeglut3-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev libxext-dev
-
-      - name: Install dependencies
-        run: julia --color=yes --project -e 'using Pkg; Pkg.instantiate();
-                using Books; Books.install_dependencies()'
 
       - run: >
           DISPLAY=:0 xvfb-run -s '-screen 0 1024x768x24' julia --project -e 'using JDS; JDS.build()'

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -32,6 +32,8 @@ jobs:
       - name: Install GLMakie dependencies
         run: sudo apt-get update && sudo apt-get install -y xorg-dev imagemagick mesa-utils xvfb libgl1 freeglut3-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev libxext-dev
 
+      - run: julia --color=yes --project -e 'using Pkg; Pkg.instantiate()'
+
       - run: >
           DISPLAY=:0 xvfb-run -s '-screen 0 1024x768x24' julia --project -e 'using JDS; JDS.build()'
         env:

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,6 @@
 name = "JDS"
 uuid = "6c596d62-2771-44f8-8373-3ec4b616ee9d"
 authors = ["Jose Storopoli", "Rik Huijzer", "Lazaro Alonso"]
-version = "0.1.0"
 
 [deps]
 Books = "939d5c6b-51ae-42e7-97ca-7564d0d4ad91"

--- a/Project.toml
+++ b/Project.toml
@@ -32,7 +32,7 @@ TestImages = "5e47fb64-e119-507b-a336-dd2b206d9990"
 XLSX = "fdbf4ff8-1666-58a4-91e7-1b58723a45e0"
 
 [compat]
-Books = "1"
+Books = "2"
 CSV = "0.10"
 CairoMakie = "0.8"
 CategoricalArrays = "0.10"

--- a/src/JDS.jl
+++ b/src/JDS.jl
@@ -1,5 +1,6 @@
 module JDS
 
+import Books
 import Pkg
 import Makie
 

--- a/src/ci.jl
+++ b/src/ci.jl
@@ -1,45 +1,10 @@
 """
-    write_thanks_page()
-
-Thanks page for when people sign up for email updates.
-"""
-function write_thanks_page()
-    text = """
-        <!DOCTYPE html>
-        <html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
-        <body>
-            <div style="margin-top: 40px; font-size: 40px; text-align: center;">
-                <br>
-                <br>
-                <br>
-                <div style="font-weight: bold;">
-                    Thank you
-                </div>
-                <br>
-                <div>
-                    You successfully signed up for email updates.
-                </div>
-                <br>
-                <br>
-                <div style="margin-bottom: 300px; font-size: 24px">
-                    <a href="/">Click here</a> to go back to the homepage.
-                </div>
-            </div>
-        </body>
-        """
-    path = joinpath(BUILD_DIR, "thanks.html")
-    write(path, text)
-    return path
-end
-
-"""
     build()
 
 This method is called during CI.
 """
 function build()
-    println("Building JDS")
-    write_thanks_page()
+    @info "Building JDS"
     fail_on_error = true
     gen(; fail_on_error)
     extra_head = """

--- a/src/makie.jl
+++ b/src/makie.jl
@@ -478,16 +478,17 @@ end
 function scatters_in_3D()
     GLMakie.activate!() # hide
     seed!(123)
-    xyz = randn(10, 3)
-    x, y, z = xyz[:, 1], xyz[:, 2], xyz[:, 3]
-    fig = Figure(resolution=(1200, 400))
+    n = 10
+    x, y, z = randn(n), randn(n), randn(n)
+    fig = Figure(; resolution=(1200, 400))
     ax1 = Axis3(fig[1, 1]; aspect=(1, 1, 1), perspectiveness=0.5)
     ax2 = Axis3(fig[1, 2]; aspect=(1, 1, 1), perspectiveness=0.5)
     ax3 = Axis3(fig[1, 3]; aspect=:data, perspectiveness=0.5)
     scatter!(ax1, x, y, z; markersize=15)
     meshscatter!(ax2, x, y, z; markersize=0.25)
     hm = meshscatter!(ax3, x, y, z; markersize=0.25,
-        marker=Rect3f(Vec3f(0), Vec3f(1)))
+        marker=Rect3f(Vec3f(0), Vec3f(1)), color=1:n,
+        colormap=:plasma, transparency=false)
     Colorbar(fig[1, 4], hm, label="values", height=Relative(0.5))
     fig
 end
@@ -495,16 +496,16 @@ end
 function lines_in_3D()
     GLMakie.activate!() # hide
     seed!(123)
-    xyz = randn(10, 3)
-    x, y, z = xyz[:, 1], xyz[:, 2], xyz[:, 3]
-    fig = Figure(resolution=(1200, 500))
+    n = 10
+    x, y, z = randn(n), randn(n), randn(n)
+    fig = Figure(; resolution=(1200, 500))
     ax1 = Axis3(fig[1, 1]; aspect=(1, 1, 1), perspectiveness=0.5)
     ax2 = Axis3(fig[1, 2]; aspect=(1, 1, 1), perspectiveness=0.5)
     ax3 = Axis3(fig[1, 3]; aspect=:data, perspectiveness=0.5)
-    lines!(ax1, x, y, z; color=1:size(xyz)[2], linewidth=3)
+    lines!(ax1, x, y, z; color=2, linewidth=3)
     scatterlines!(ax2, x, y, z; markersize=15)
-    hm = meshscatter!(ax3, x, y, z; markersize=0.2, color=1:size(xyz,2))
-    lines!(ax3, x, y, z; color=1:size(xyz,2))
+    hm = meshscatter!(ax3, x, y, z; markersize=0.2, color=1:n)
+    lines!(ax3, x, y, z; color=1:n)
     Colorbar(fig[2, 1], hm; label="values", height=15, vertical=false,
         flipaxis=false, ticksize=15, tickalign=1, width=Relative(3.55 / 4))
     fig

--- a/src/makie.jl
+++ b/src/makie.jl
@@ -487,8 +487,7 @@ function scatters_in_3D()
     scatter!(ax1, x, y, z; markersize=15)
     meshscatter!(ax2, x, y, z; markersize=0.25)
     hm = meshscatter!(ax3, x, y, z; markersize=0.25,
-        marker=Rect3f(Vec3f(0), Vec3f(1)), color=1:size(xyz,2),
-        colormap=:plasma, transparency=false)
+        marker=Rect3f(Vec3f(0), Vec3f(1)))
     Colorbar(fig[1, 4], hm, label="values", height=Relative(0.5))
     fig
 end

--- a/src/makie.jl
+++ b/src/makie.jl
@@ -1,5 +1,12 @@
-const MAKIE_PLOT_TYPES = Union{CairoMakie.Makie.Figure, CairoMakie.Makie.FigureAxisPlot}
-_makie_save(path::String, p) = CairoMakie.FileIO.save(path, p; px_per_unit=3)
+const MAKIE_PLOT_TYPES = Union{Figure, Makie.FigureAxisPlot}
+function _makie_save(path::String, p)
+    try
+        # SVG doesn't work with GLMakie.
+        FileIO.save(path, p; px_per_unit=3)
+    catch
+        @warn "Couldn't save $path"
+    end
+end
 
 Books.is_image(plot::MAKIE_PLOT_TYPES) = true
 Books.svg(svg_path::String, p::MAKIE_PLOT_TYPES) = _makie_save(svg_path, p)
@@ -502,7 +509,7 @@ function lines_in_3D()
     ax1 = Axis3(fig[1, 1]; aspect=(1, 1, 1), perspectiveness=0.5)
     ax2 = Axis3(fig[1, 2]; aspect=(1, 1, 1), perspectiveness=0.5)
     ax3 = Axis3(fig[1, 3]; aspect=:data, perspectiveness=0.5)
-    lines!(ax1, x, y, z; color=2, linewidth=3)
+    lines!(ax1, x, y, z; color=1:n, linewidth=3)
     scatterlines!(ax2, x, y, z; markersize=15)
     hm = meshscatter!(ax3, x, y, z; markersize=0.2, color=1:n)
     lines!(ax3, x, y, z; color=1:n)

--- a/src/makie.jl
+++ b/src/makie.jl
@@ -1,3 +1,10 @@
+const MAKIE_PLOT_TYPES = Union{CairoMakie.Makie.Figure, CairoMakie.Makie.FigureAxisPlot}
+_makie_save(path::String, p) = CairoMakie.FileIO.save(path, p; px_per_unit=3)
+
+Books.is_image(plot::MAKIE_PLOT_TYPES) = true
+Books.svg(svg_path::String, p::MAKIE_PLOT_TYPES) = _makie_save(svg_path, p)
+Books.png(png_path::String, p::MAKIE_PLOT_TYPES) = _makie_save(png_path, p)
+
 function custom_plot()
     CairoMakie.activate!() # hide
     caption = "An example plot with Makie.jl."

--- a/src/makie.jl
+++ b/src/makie.jl
@@ -2,9 +2,10 @@ const MAKIE_PLOT_TYPES = Union{Figure, Makie.FigureAxisPlot}
 function _makie_save(path::String, p)
     try
         # SVG doesn't work with GLMakie.
+        # Doesn't matter since Books.jl will only show SVG if it is available.
+        # Otherwise, it will show the PNG (HTML).
         FileIO.save(path, p; px_per_unit=3)
     catch
-        @warn "Couldn't save $path"
     end
 end
 


### PR DESCRIPTION
I'm having a bit of trouble running this locally (NixOS nor Docker manage to run all blocks :sweat_smile:), but if CI passes then all should be good. Unless there are objections, I'm planning to send an updated PDF to Amazon because syntax highlighting is disabled for output blocks now which looks better.

### `Books.jl` v2 release notes

Version 2 closes about 6 long-standing issues. Most noteworthy:

- Syntax highlighting is disabled for output blocks in both HTML and PDF. This makes the books and websites look much cleaner.
- The output is printed via `ProgressMeter.jl` instead of a dump to the console. This avoids a lot of scrolling when using `gen`.
- All code is now always evaluated in `Main`. There used to be two ways to do it, but having one is much simpler and therefore better.
- Yggdrasil is now used for Tectonic so Tectonic will automatically update with Yggdrasil and supports ARM via their build system (pandoc-crossref doesn't yet unfortunately)
- docx is removed because, well, it's docx
- `install_dependencies` is avoided by passing JuliaMono directly into the TeX file. This avoids the need for a globally installed JuliaMono
