### PR TITLE
Use `eachindex` instead of `1:length`

### DIFF
--- a/contents/julia_basics.md
+++ b/contents/julia_basics.md
@@ -679,7 +679,7 @@ For example, we can create a function that adds 1 to each element in a vector `V
 ```jl
 s = """
     function add_one!(V)
-        for i in 1:length(V)
+        for i in eachindex(V)
             V[i] += 1
         end
         return nothing


### PR DESCRIPTION
`1:length` depends on the endpoints of the indexing, so is unsafe for OffsetArrays. `eachindex` is more generic and clear about the intent of the operation.