### PR TITLE
Edit for clarity

### DIFF
--- a/contents/dataframes.md
+++ b/contents/dataframes.md
@@ -2,7 +2,7 @@
 
 Data comes mostly in a tabular format.
 By tabular, we mean that the data consists of a table containing rows and columns.
-Columns are usually of the same data type, whereas rows have different types.
+Entries within any one column are usually of the same data type, whereas entries within a given row typically have different types.
 The rows, in practice, denote observations while columns denote variables.
 For example, we can have a table of TV shows containing the country in which each was produced and our personal rating, see @tbl:TV_shows.
 


### PR DESCRIPTION
The original wording can be confusing to a naïve reader.  For example, the phrase "Columns are usually of the same data type" sounds like it is saying that columns have a data type and this type is usually the same for all columns.  I think it is clearer to state that all the elements in a given column share the same data type.