### PR TITLE
ci: add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: daily

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,4 +3,4 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: daily
+      interval: weekly

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -9,9 +9,9 @@ on:
 
 jobs:
   BuildAndDeploy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           persist-credentials: false
 

--- a/.github/workflows/Format.yml
+++ b/.github/workflows/Format.yml
@@ -10,9 +10,9 @@ on:
 jobs:
   docs:
     name: CheckFormatting
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - shell: julia --project=format --color=yes {0}
         run: |


### PR DESCRIPTION
Also updates some old actions that were giving warnings on CI. Changes the runner machines to all be ubuntu-latest which is the latest LTS ubuntu.