### PR TITLE
fix(makie): warnings from 0.20 migration

### DIFF
--- a/contents/data_vis_makie.md
+++ b/contents/data_vis_makie.md
@@ -52,7 +52,7 @@ Now, we will start with some basic plots and later one some more advanced public
 But, before going into plotting it is important to know how to save our plots.
 The easiest option to `save` a figure `fig` is to type `save("filename.png", fig)`.
 Other formats are also available for `CairoMakie.jl`, such as `svg` and `pdf`.
-The resolution of the output image can easily be adjusted by passing extra arguments.
+The size of the output image can easily be adjusted by passing extra arguments.
 For example, for vector formats you specify `pt_per_unit`:
 
 ```
@@ -66,7 +66,7 @@ save("filename.pdf", fig; pt_per_unit=0.5)
 ```
 
 For `png`'s you specify `px_per_unit`.
-See [Exporting a Figure with physical dimensions](https://docs.makie.org/stable/documentation/figure_size/) for details.
+See [Exporting a Figure with physical dimensions](https://docs.makie.org/stable/explanations/figure/#figure_size_and_units) for details.
 
 Another important issue is to actually visualize your output plot.
 Note that for `CairoMakie.jl` the Julia REPL is not able to show plots, so you will need an IDE (Integrated Development Environment) such as VSCode, Jupyter or Pluto that supports `png` or `svg` as output.

--- a/contents/data_vis_makie_colors.md
+++ b/contents/data_vis_makie_colors.md
@@ -34,7 +34,7 @@ See `?cgrad` for more information.
 ```jl
 scolor = """
     CairoMakie.activate!() # hide
-    figure = (; resolution=(600, 400), font="CMU Serif")
+    figure = (; size=(600, 400), font="CMU Serif")
     axis = (; xlabel=L"x", ylabel=L"y", aspect=DataAspect())
     fig, ax, pltobj = heatmap(rand(20, 20); colorrange=(0, 1),
         colormap=Reverse(:viridis), axis=axis, figure=figure)
@@ -61,7 +61,7 @@ using ColorSchemes
 ```jl
 s = """
     CairoMakie.activate!() # hide
-    figure = (; resolution=(600, 400), font="CMU Serif")
+    figure = (; size=(600, 400), font="CMU Serif")
     axis = (; xlabel=L"x", ylabel=L"y", aspect=DataAspect())
     fig, ax, pltobj = heatmap(randn(20, 20); colorrange=(-2, 2),
         colormap="diverging_rainbow_bgymr_45_85_c67_n256",
@@ -90,7 +90,7 @@ using Colors, ColorSchemes
 ```jl
 scat = """
     CairoMakie.activate!() # hide
-    figure = (; resolution=(600, 400), font="CMU Serif")
+    figure = (; size=(600, 400), font="CMU Serif")
     axis = (; xlabel=L"x", ylabel=L"y", aspect=DataAspect())
     #cmap = ColorScheme(range(colorant"red", colorant"green", length=3))
     # this is another way to obtain a colormap, not used here, but try it.
@@ -120,7 +120,7 @@ Also, hexadecimal coded colors are accepted. So, on top of our heatmap let's put
 ```jl
 s2color2 = """
     CairoMakie.activate!() # hide
-    figure = (; resolution=(600, 400), font="CMU Serif")
+    figure = (; size=(600, 400), font="CMU Serif")
     axis = (; xlabel=L"x", ylabel=L"y", aspect=DataAspect())
     fig, ax, pltobj = heatmap(rand(20, 20); colorrange=(0, 1),
         colormap=["red", "black"], axis=axis, figure=figure)

--- a/contents/data_vis_makie_create_figure.md
+++ b/contents/data_vis_makie_create_figure.md
@@ -96,7 +96,7 @@ s = """
             ygridstyle=:dash,
             ),
         Legend=(;
-            bgcolor=(:grey, 0.1),
+            backgroundcolor=(:grey, 0.1),
             framecolor=:orangered,
             ),
         )

--- a/contents/data_vis_makie_create_figure.md
+++ b/contents/data_vis_makie_create_figure.md
@@ -1,7 +1,7 @@
 ## Create Plot Figure {#sec:datavisMakie_create_Figure}
 The basic container object in Makie is `Figure`, a canvas where we can add objects like `Axis`, `Colorbar`, `Legend`, etc.
 
-For `Figure`, we have have attributes like `backgroundcolor`, `resolution`, `font` and `fontsize` as well as the `figure_padding` which changes the amount of space around the figure content, see the colored area in @fig:fig_axis.
+For `Figure`, we have have attributes like `backgroundcolor`, `size`, `font` and `fontsize` as well as the `figure_padding` which changes the amount of space around the figure content, see the colored area in @fig:fig_axis.
 It can take one number for all sides, or a tuple of four numbers for left, right, bottom and top. Let's dive into these components.
 
 ### Figure
@@ -85,7 +85,7 @@ We can do this with `set_theme!()` as follows:
 ```jl
 s = """
     set_theme!(;
-        resolution=(600,400),
+        size=(600,400),
         backgroundcolor=(:mistyrose, 0.1),
         fontsize=16,
         Axis=(;

--- a/contents/data_vis_makie_layouts.md
+++ b/contents/data_vis_makie_layouts.md
@@ -135,7 +135,7 @@ Then, the `inset` is easily done, as in:
 @sco JDS.figure_box_inset()
 ```
 
-where the `Box` dimensions are bound by the `Figure`'s `resolution`.
+where the `Box` dimensions are bound by the `Figure`'s `size`.
 Note, that an inset can be also outside the `Axis`.
 The other approach, is by defining a new `Axis` into a position `fig[i, j]` specifying his `width`, `height`, `halign` and `valign`.
 We do that in the following function:

--- a/contents/data_vis_makie_themes.md
+++ b/contents/data_vis_makie_themes.md
@@ -59,13 +59,13 @@ sco(s)
 
 Here we have use `with_theme` which is more convenient for the direct application of a theme than the `do` syntax. You should use the latter if you want to include extra arguments to the theme that is going to be applied.
 
-Now, if something needs to be changed after `set_theme!(your_theme)`, we can do it with `update_theme!(resolution=(500, 400), fontsize=18)`, for example.
+Now, if something needs to be changed after `set_theme!(your_theme)`, we can do it with `update_theme!(size=(500, 400), fontsize=18)`, for example.
 Another approach will be to pass additional arguments to the `with_theme` function:
 
 ```jl
 s = """
     CairoMakie.activate!() # hide
-    fig = (resolution=(600, 400), figure_padding=1, backgroundcolor=:grey90)
+    fig = (size=(600, 400), figure_padding=1, backgroundcolor=:grey90)
     ax = (; aspect=DataAspect(), xlabel=L"x", ylabel=L"y")
     cbar = (; height=Relative(4 / 5))
     with_theme(publication_theme(); fig..., Axis=ax, Colorbar=cbar) do

--- a/contents/stats_distributions.md
+++ b/contents/stats_distributions.md
@@ -44,7 +44,7 @@ We can create a scatter plot for these numbers:
 ```jl
 s = """
     CairoMakie.activate!() # hide
-    figure = (; resolution=(600, 400))
+    figure = (; size=(600, 400))
     xlabel = "number of times fallen to the right"
     axis = (; xlabel, ylabel="ball")
     scatter(X, 1:n_repeats; figure, axis)
@@ -68,7 +68,7 @@ This is called a **hist**ogram:
 
 ```jl
 s = """
-    figure = (; resolution=(600, 400))
+    figure = (; size=(600, 400))
     axis = (; xlabel, ylabel="balls per bin")
     hist(X; figure, axis)
     label = "first_histogram" # hide

--- a/contents/stats_vis.md
+++ b/contents/stats_vis.md
@@ -19,7 +19,7 @@ s = """
     label = "histogram" # hide
     caption = "Histogram" # hide
     df = more_grades()
-    fig = Figure(; resolution=(600, 400))
+    fig = Figure(; size=(600, 400))
     ax = Axis(fig[1, 1], xticks=1:10)
     hist!(ax, df.grade; color=(:dodgerblue, 0.5))
     Options(current_figure(); filename=label, caption, label) # hide
@@ -36,7 +36,7 @@ s = """
     label = "histogram_bins" # hide
     caption = "Histogram with Custom Bins" # hide
     df = more_grades()
-    fig = Figure(; resolution=(600, 400))
+    fig = Figure(; size=(600, 400))
     ax = Axis(fig[1, 1], xticks=1:10)
     hist!(ax, df.grade; color=(:dodgerblue, 0.5), bins=10)
     Options(current_figure(); filename=label, caption, label) # hide
@@ -69,7 +69,7 @@ s = """
     caption = "Box Plot" # hide
     df = more_grades()
     transform!(df, :name => categorical; renamecols=false)
-    fig = Figure(; resolution=(600, 400))
+    fig = Figure(; size=(600, 400))
     ax = Axis(fig[1, 1]; xticks = (1:4, levels(df.name)))
     boxplot!(ax, levelcode.(df.name), df.grade)
     Options(current_figure(); filename=label, caption, label) # hide
@@ -88,7 +88,7 @@ s = """
     caption = "Box Plot with different IQR and Whiskers Vertical Bars" # hide
     df = more_grades()
     transform!(df, :name => categorical; renamecols=false)
-    fig = Figure(; resolution=(600, 400))
+    fig = Figure(; size=(600, 400))
     ax = Axis(fig[1, 1]; xticks = (1:4, levels(df.name)))
     boxplot!(ax, levelcode.(df.name), df.grade; range=2.0, whiskerwidth=0.5)
     Options(current_figure(); filename=label, caption, label) # hide
@@ -106,7 +106,7 @@ s = """
     caption = "Box Plot with Outliers" # hide
     df = more_grades()
     transform!(df, :name => categorical; renamecols=false)
-    fig = Figure(; resolution=(600, 400))
+    fig = Figure(; size=(600, 400))
     ax = Axis(fig[1, 1]; xticks = (1:4, levels(df.name)))
     boxplot!(ax, levelcode.(df.name), df.grade; range=0.5, show_outliers=true)
     Options(current_figure(); filename=label, caption, label) # hide
@@ -141,7 +141,7 @@ s = """
     transform!(df, :name => categorical; renamecols=false)
     categories = levels(df.name)
     values(code) = filter(row -> levelcode.(row.name) == code, df).grade
-    fig = Figure(; resolution=(600, 400))
+    fig = Figure(; size=(600, 400))
     ax = Axis(fig[1, 1]; yticks = (1:4, categories), limits=((-1, 11), nothing))
     for i in 1:eachindex(categories)
         density!(ax, values(i); offset=i)
@@ -163,7 +163,7 @@ s = """
     transform!(df, :name => categorical; renamecols=false)
     categories = levels(df.name)
     values(code) = filter(row -> levelcode.(row.name) == code, df).grade
-    fig = Figure(; resolution=(600, 400))
+    fig = Figure(; size=(600, 400))
     ax1 = Axis(fig[1, 1]; yticks = (1:4, categories), limits=((-1, 11), nothing))
     ax2 = Axis(fig[1, 2]; yticks = (1:4, categories), limits=((-1, 11), nothing))
     for i in 1:eachindex(categories)

--- a/src/cheatSheet_cairo.jl
+++ b/src/cheatSheet_cairo.jl
@@ -8,9 +8,9 @@ function cheatsheet_cairomakie()
     packages = ["Makie", "CairoMakie"]
     seed!(123)
     CairoMakie.activate!()
-    x = range(0, 2π, length=12)
+    x = range(0, 2π; length=12)
     fig = with_theme(theme_light()) do
-        fig = Figure(resolution=(1000, 1600))
+        fig = Figure(; size=(1000, 1600))
         axs = [Axis(fig[i, j], aspect=1) for i = 1:7 for j = 1:5]
 
         lines!(axs[1], x, sin.(x))

--- a/src/cheatSheet_glmakie.jl
+++ b/src/cheatSheet_glmakie.jl
@@ -4,7 +4,7 @@ function cheatsheet_glmakie()
     seed!(123)
     GLMakie.activate!()
     fig = with_theme(theme_light()) do
-       fig = Figure(resolution=(1000, 1600))
+       fig = Figure(; size=(1000, 1600))
         axs1 = Axis(fig[1, 1], aspect=1)
         axs2 = Axis(fig[1, 2], aspect=1)
         axs3 = Axis(fig[1, 3], aspect=1, xscale=log10, yscale=log10)

--- a/src/cheatSheet_glmakie.jl
+++ b/src/cheatSheet_glmakie.jl
@@ -169,7 +169,7 @@ function cheatsheet_glmakie()
         rectMesh = Rect3f(Vec3f(-0.5), Vec3f(1))
         recmesh = GeometryBasics.mesh(rectMesh)
         colors = [rand() for v in recmesh.position]
-        mesh!(axs[15], recmesh; color=colors, colormap=:rainbow, shading=false)
+        mesh!(axs[15], recmesh; color=colors, colormap=:rainbow, shading=NoShading)
         axs[15].title = "mesh(Rect3f; color)"
 
         meshscatter!(axs[16], [Point3f(rand(3)...) for i = 1:4];
@@ -196,19 +196,19 @@ function cheatsheet_glmakie()
 
         #pos = [Point3f(i, j, 0) for i in 1:10 for j in 1:10]
         #z = rand(10,10)
-        mesh!(axs[19], rectmesh, color=colors, shading=false,
+        mesh!(axs[19], rectmesh, color=colors, shading=NoShading,
             colormap=:tableau_blue_green, #[:black, :yellow, :red]
         )
         axs[19].title = "mesh(;color)"
 
         #zlims!(axs[19], 0, 1)
         mesh!(axs[20], rectMesh, color=testimage("monarch_color_256"),
-            shading=false, interpolate=false)
+            shading=NoShading, interpolate=false)
         axs[20].title = "mesh(;color=img)"
 
         mesh!(axs[21], Sphere(Point3f(0), 1);
             color=testimage("mandril_color"),
-            shading=false)
+            shading=NoShading)
         axs[21].title = "mesh(;color=img)"
 
         wireframe!(axs[22], Rect3f(Vec3f(-0.5), Vec3f(1));
@@ -258,7 +258,7 @@ function cheatsheet_glmakie()
             markersize=0.9,
             colormap=:seaborn_icefire_gradient, #Reverse(:linear_protanopic_deuteranopic_kbw_5_98_c40_n256),
             colorrange=(minimum(vals), maximum(vals)),
-            shading=true,
+            shading=MultiLightShading,
             transparency=true,
         )
         axs[25].title = "meshscatter(pos;\nmarker=Rect3f)"

--- a/src/cover.jl
+++ b/src/cover.jl
@@ -6,7 +6,7 @@ Return the book cover.
 function cover()
     width = 2 * 2016
     height = (10 / 7) * width # Ratio 7 * 10 inch.
-    fig = Figure(; resolution=(width, height))
+    fig = Figure(; size=(width, height))
     # fig[1, 2] = Scene(front_cover())
     # return fig
 

--- a/src/front-cover.jl
+++ b/src/front-cover.jl
@@ -50,7 +50,7 @@ function front_cover()
 
         width = 2016
         height = (10 / 7) * width # Ratio 7 * 10 inch.
-        fig = Figure(figure_padding=(50, 15, 5, 5), resolution=(width, height))
+        fig = Figure(; figure_padding=(50, 15, 5, 5), size=(width, height))
         # Colors
         colors = ColorSchemes.Set1_6
         #colors = Makie.wong_colors()

--- a/src/front-cover.jl
+++ b/src/front-cover.jl
@@ -85,32 +85,32 @@ function front_cover()
             marker=FRect3D(Vec3f0(0), Vec3f0(7)), # here, if you use less than 10, you will see smaller squares.
             colormap=:linear_grey_10_95_c0_n256, colorrange=(-2, 2),
             transparency=false,
-            shading=false)
+            shading=NoShading)
         meshscatter!(ax11, posTops, color=vec(valsTop), marker=FRect3D(Vec3f0(0), Vec3f0(7)),
             transparency=false, colormap=(:plasma, 0.65),
-            shading=false, colorrange=(0, 1))
+            shading=NoShading, colorrange=(0, 1))
         meshscatter!(ax11, posSides, color=vec(valsSides), marker=FRect3D(Vec3f0(0), Vec3f0(7)),
             transparency=false, colormap=(:viridis, 0.65),
-            shading=false)
-        meshscatter!(ax21, vec(arrTop[:, end]), color=colorTop[end:-1:1], shading=false,
+            shading=NoShading)
+        meshscatter!(ax21, vec(arrTop[:, end]), color=colorTop[end:-1:1], shading=NoShading,
             marker=FRect3D(Vec3f0(0), Vec3f0(7)), colormap=:plasma, colorrange=(0, 1))
-        meshscatter!(ax21, vec([(0, i) for i = 0:9]), color=colorSides, shading=false,
+        meshscatter!(ax21, vec([(0, i) for i = 0:9]), color=colorSides, shading=NoShading,
             marker=FRect3D(Vec3f0(0), Vec3f0(7)), colormap=:viridis, colorrange=(0, 1))
-        meshscatter!(ax21, vec([(j, i) for i = 0:9, j = 1:10]), shading=false,
+        meshscatter!(ax21, vec([(j, i) for i = 0:9, j = 1:10]), shading=NoShading,
             color=vec(vals[end:-1:1, end, :]'),
             marker=FRect3D(Vec3f0(0), Vec3f0(7)), colormap=:linear_grey_10_95_c0_n256, colorrange=(-2, 2))
-        meshscatter!(ax31, vec(arrTop[1:2, end]), color=colorTop[end:-1:1][1:2], shading=false,
+        meshscatter!(ax31, vec(arrTop[1:2, end]), color=colorTop[end:-1:1][1:2], shading=NoShading,
             marker=FRect3D(Vec3f0(0), Vec3f0(7)), colormap=:plasma, colorrange=(0, 1))
-        meshscatter!(ax31, vec([(0, i) for i = 0:9]), color=colorSides, shading=false,
+        meshscatter!(ax31, vec([(0, i) for i = 0:9]), color=colorSides, shading=NoShading,
             marker=FRect3D(Vec3f0(0), Vec3f0(7)), colormap=:viridis, colorrange=(0, 1))
-        meshscatter!(ax31, vec([(j, i) for i = 0:9, j = 1:2]), shading=false,
+        meshscatter!(ax31, vec([(j, i) for i = 0:9, j = 1:2]), shading=NoShading,
             color=vec(vals[end:-1:1, end, :]')[1:20],
             marker=FRect3D(Vec3f0(0), Vec3f0(7)), colormap=:linear_grey_10_95_c0_n256, colorrange=(-2, 2))
-        meshscatter!(ax41, vec(arrTop[1:1, end]), color=colorTop[end:-1:1][1:1], shading=false,
+        meshscatter!(ax41, vec(arrTop[1:1, end]), color=colorTop[end:-1:1][1:1], shading=NoShading,
             marker=FRect3D(Vec3f0(0), Vec3f0(7)), colormap=:plasma, colorrange=(0, 1))
-        meshscatter!(ax41, vec([(0, i) for i = 0:9]), color=colorSides, shading=false,
+        meshscatter!(ax41, vec([(0, i) for i = 0:9]), color=colorSides, shading=NoShading,
             marker=FRect3D(Vec3f0(0), Vec3f0(7)), colormap=:viridis, colorrange=(0, 1))
-        meshscatter!(ax41, vec([(j, i) for i = 0:9, j = 1:1]), shading=false,
+        meshscatter!(ax41, vec([(j, i) for i = 0:9, j = 1:1]), shading=NoShading,
             color=vec(vals[end:-1:1, end, :]')[1:10],
             marker=FRect3D(Vec3f0(0), Vec3f0(7)), colormap=:linear_grey_10_95_c0_n256, colorrange=(-2, 2))
         # Limits

--- a/src/makie.jl
+++ b/src/makie.jl
@@ -229,7 +229,7 @@ publication_theme() = Theme(
         yticksize=10, xticksize=10,
         xlabel="x", ylabel="y"
         ),
-    Legend=(framecolor=(:black, 0.5), bgcolor=(:white, 0.5)),
+    Legend=(framecolor=(:black, 0.5), backgroundcolor=(:white, 0.5)),
     Colorbar=(ticksize=16, tickalign=1, spinewidth=0.5),
 )
 
@@ -359,7 +359,7 @@ function demo_figure()
     Legend(fig[1,2, Top()], ax2;
         orientation=:horizontal,
         nbanks=2,
-        bgcolor =:transparent,
+        backgroundcolor =:transparent,
         tellheight=false,
         valign=:center,
         )
@@ -446,7 +446,7 @@ function new_cycle_theme()
             xtickalign=1, ytickalign=1,
             yticksize=10, xticksize=10,
             xlabel="x", ylabel="y"),
-        Legend=(framecolor=(:black, 0.5), bgcolor=(:white, 0.5)),
+        Legend=(framecolor=(:black, 0.5), backgroundcolor=(:white, 0.5)),
         Colorbar=(ticksize=16, tickalign=1, spinewidth=0.5),
     )
 end
@@ -653,20 +653,20 @@ function nested_Grid_Layouts()
     Options(fig; caption, label, link_attributes) # hide
 end
 
-function add_box_inset(fig; bgcolor=:snow2,
+function add_box_inset(fig; backgroundcolor=:snow2,
     left=100, right=250, bottom=200, top=300)
     # https://discourse.julialang.org/t/makie-inset-axes-and-their-drawing-order/60987 # hide
     inset_box = Axis(fig, bbox=BBox(left, right, bottom, top),
-        xticklabelsize=12, yticklabelsize=12, backgroundcolor=bgcolor)
+        xticklabelsize=12, yticklabelsize=12, backgroundcolor=backgroundcolor)
     translate!(inset_box.scene, 0, 0, 10)  # bring content upfront
     return inset_box
 end
 
-function add_axis_inset(pos=fig[1, 1]; bgcolor=:snow2,
+function add_axis_inset(pos=fig[1, 1]; backgroundcolor=:snow2,
     halign, valign, width=Relative(0.5),height=Relative(0.35),
     alignmode=Mixed(left=5, right=5))
     inset_box = Axis(pos; width, height, halign, valign, alignmode,
-        xticklabelsize=12, yticklabelsize=12, backgroundcolor=bgcolor)
+        xticklabelsize=12, yticklabelsize=12, backgroundcolor=backgroundcolor)
     # bring content upfront
     translate!(inset_box.scene, 0, 0, 10)
     return inset_box
@@ -676,11 +676,11 @@ function figure_axis_inset()
     CairoMakie.activate!() # hide
     fig = Figure(size=(600, 400))
     ax = Axis(fig[1, 1], backgroundcolor=:white)
-    inset_ax1 = add_axis_inset(fig[1, 1]; bgcolor=:snow2,
+    inset_ax1 = add_axis_inset(fig[1, 1]; backgroundcolor=:snow2,
         halign=:left, valign=:center,
         width=Relative(0.3), height=Relative(0.35),
         alignmode=Mixed(left=5, right=5, bottom=15))
-    inset_ax2 = add_axis_inset(fig[1, 1]; bgcolor=(:white, 0.85),
+    inset_ax2 = add_axis_inset(fig[1, 1]; backgroundcolor=(:white, 0.85),
         halign=:right, valign=:center,
         width=Relative(0.25), height=Relative(0.3))
     lines!(ax, 1:10)
@@ -697,9 +697,9 @@ function figure_box_inset()
     CairoMakie.activate!() # hide
     fig = Figure(size=(600, 400))
     ax = Axis(fig[1, 1], backgroundcolor=:white)
-    inset_ax1 = add_box_inset(fig; bgcolor=:snow2,
+    inset_ax1 = add_box_inset(fig; backgroundcolor=:snow2,
         left=100, right=250, bottom=200, top=300)
-    inset_ax2 = add_box_inset(fig; bgcolor=(:white, 0.85),
+    inset_ax2 = add_box_inset(fig; backgroundcolor=(:white, 0.85),
         left=500, right=580, bottom=100, top=200)
     lines!(ax, 1:10)
     lines!(inset_ax1, 1:10)

--- a/src/makie.jl
+++ b/src/makie.jl
@@ -819,7 +819,7 @@ function mixing_surface_contour3d_contour_and_contourf()
         zgridcolor=:grey70, ygridcolor=:grey70, xgridcolor=:grey70)
     ax2 = Axis3(fig[1, 3]; aspect=(1, 1, 1),
         elevation=π/6, perspectiveness=0.5)
-    hm = surface!(ax1, x, y, z; colormap=(cmap, 0.95), shading=true)
+    hm = surface!(ax1, x, y, z; colormap=(cmap, 0.95), shading=MultiLightShading)
     contour3d!(ax1, x, y, z .+ 0.02; colormap=cmap, levels=20, linewidth=2)
     # get final limits
     xmin, ymin, zmin = minimum(ax1.finallimits[])
@@ -886,7 +886,7 @@ function mesh_volume_contour()
     vals = randn(10, 10, 10)
     fig = Figure(size=(1200, 400))
     axs = [Axis3(fig[1, i]; aspect=(1,1,1), perspectiveness=0.5) for i=1:3]
-    mesh!(axs[1], recmesh; color=colors, colormap=:rainbow, shading=false)
+    mesh!(axs[1], recmesh; color=colors, colormap=:rainbow, shading=NoShading)
     mesh!(axs[1], spheremesh; color=(:white, 0.25), transparency=true)
     volume!(axs[2], x, y, z, vals; colormap=Reverse(:plasma))
     contour!(axs[3], x, y, z, vals; colormap=Reverse(:plasma))
@@ -930,12 +930,12 @@ function grid_spheres_and_rectangle_as_plate()
         ax1 = Axis3(fig[1, 1]; aspect, perspectiveness, azimuth=0.72)
         ax2 = Axis3(fig[1, 2]; aspect, perspectiveness)
         meshscatter!(ax1, spheresGrid; color=colorSphere, markersize=1,
-            shading=false)
+            shading=NoShading)
         meshscatter!(ax2, spheresPlane; color=colorsPlane, markersize=0.75,
             lightposition=Vec3f(10, 5, 2),
             ambient=Vec3f(0.95, 0.95, 0.95),
             backlight=1.0f0)
-        mesh!(recmesh; color=colors, colormap=:rainbow, shading=false)
+        mesh!(recmesh; color=colors, colormap=:rainbow, shading=NoShading)
         limits!(ax1, 0, 10, 0, 10, 0, 10)
         fig
     end
@@ -962,11 +962,11 @@ function histogram_or_bars_in_3d()
     rectMesh = Rect3f(Vec3f(-0.5, -0.5, 0), Vec3f(1, 1, 1))
     meshscatter!(ax1, x, y, 0 * z; marker=rectMesh, color=z[:],
         markersize=Vec3f.(2δx, 2δy, z[:]), colormap=:Spectral_11,
-        shading=false)
+        shading=NoShading)
     limits!(ax1, -3.5, 3.5, -3.5, 3.5, -7.45, 7.45)
     meshscatter!(ax2, x, y, 0 * z; marker=rectMesh, color=z[:],
         markersize=Vec3f.(2δx, 2δy, z[:]), colormap=(:Spectral_11, 0.25),
-        shading=false, transparency=true)
+        shading=NoShading, transparency=true)
     for (idx, i) in enumerate(x), (idy, j) in enumerate(y)
         rectMesh=Rect3f(Vec3f(i-δx, j-δy, 0), Vec3f(2δx, 2δy, z[idx,idy]))
         recmesh=GeometryBasics.mesh(rectMesh)

--- a/src/makie.jl
+++ b/src/makie.jl
@@ -19,7 +19,7 @@ function figure_canvas()
     fig = Figure(;
         figure_padding=(5,5,10,10),
         backgroundcolor=:snow2,
-        resolution=(600,400),
+        size=(600,400),
         )
     label="fig" # hide
     link_attributes = "width=60%" # hide
@@ -32,7 +32,7 @@ function figure_axis()
     fig = Figure(;
         figure_padding=(5,5,10,10),
         backgroundcolor=:snow2,
-        resolution=(600,400),
+        size=(600,400),
         )
     ax = Axis(fig[1,1];
         xlabel="x",
@@ -51,7 +51,7 @@ function figure_axis_plot()
     fig = Figure(;
         figure_padding=(5,5,10,10),
         backgroundcolor=:snow2,
-        resolution=(600,400),
+        size=(600,400),
         )
     ax = Axis(fig[1,1];
         xlabel="x",
@@ -75,7 +75,7 @@ function figure_axis_plot_leg()
     fig = Figure(;
         figure_padding=(5,5,10,10),
         backgroundcolor=:snow2,
-        resolution=(600,400),
+        size=(600,400),
         )
     ax = Axis(fig[1,1];
         xlabel="x",
@@ -129,7 +129,7 @@ end
 
 function fig_bubbles(xyz)
     CairoMakie.activate!() # hide
-    fig = Figure(resolution=(600,400))
+    fig = Figure(size=(600,400))
     ax = Axis(fig[1,1]; aspect = DataAspect())
     pltobj = scatter!(xyz[:, 1], xyz[:, 2];
         color=xyz[:, 3],
@@ -153,7 +153,7 @@ function custom_plot()
     label = missing
     x = 1:10
     fig, ax, _ = lines(x, x .^ 2, color=:black, linewidth=2, linestyle=".-",
-        label="x²", figure=(; resolution=(700, 450), fontsize=18,
+        label="x²", figure=(; size=(700, 450), fontsize=18,
             backgroundcolor="#D0DFE6FF"), axis=(xlabel="x", ylabel="x²",
             backgroundcolor=:white))
     axislegend("legend", position=:lt)
@@ -167,7 +167,7 @@ function custom_plot2()
     CairoMakie.activate!() # hide
     x = 1:10
     lines(x, x .^ 2, color=:black, linewidth=2, linestyle=".-",
-        label="x²", figure=(; resolution=(700, 450), fontsize=18,
+        label="x²", figure=(; size=(700, 450), fontsize=18,
             backgroundcolor="#D0DFE6FF"), axis=(xlabel="x", ylabel="x²",
             backgroundcolor=:white))
     axislegend("legend", position=:lt)
@@ -181,7 +181,7 @@ function areaUnder()
     CairoMakie.activate!() # hide
     x = 0:0.05:1
     y = x .^ 2
-    fig = Figure(resolution=(700, 450))
+    fig = Figure(size=(700, 450))
     ax = Axis(fig, xlabel="x", ylabel="y")
     linea = lines!(x, y, color=:dodgerblue)
     fillB = band!(x, fill(0, length(x)), y; color=(:dodgerblue, 0.1))
@@ -210,7 +210,7 @@ function LaTeX_Strings()
     x = 0:0.05:4π
     lines(x, x -> sin(3x) / (cos(x) + 2) / x;
         label=L"\frac{\sin(3x)}{x(\cos(x)+2)}",
-        figure=(; resolution=(600, 400)), axis=(; xlabel=L"x")
+        figure=(; size=(600, 400)), axis=(; xlabel=L"x")
         )
     lines!(x, x -> cos(x) / x; label=L"\cos(x)/x")
     lines!(x, x -> exp(-x); label=L"e^{-x}")
@@ -248,7 +248,7 @@ end
 function multiple_lines()
     CairoMakie.activate!() # hide
     x = collect(0:10)
-    fig = Figure(resolution=(600, 400), font="CMU Serif")
+    fig = Figure(size=(600, 400), font="CMU Serif")
     ax = Axis(fig[1, 1], xlabel=L"x", ylabel=L"f(x,a)")
     for i = 0:10
         lines!(ax, x, i .* x; label=latexstring("$(i) x"))
@@ -267,7 +267,7 @@ function multiple_scatters_and_lines()
     x = collect(0:10)
     cycle = Cycle([:color, :linestyle, :marker], covary=true)
     set_theme!(Lines=(cycle=cycle,), Scatter=(cycle=cycle,))
-    fig = Figure(resolution=(600, 400), font="CMU Serif")
+    fig = Figure(size=(600, 400), font="CMU Serif")
     ax = Axis(fig[1, 1], xlabel=L"x", ylabel=L"f(x,a)")
     for i in x
         lines!(ax, x, i .* x; label=L"%$i x")
@@ -287,7 +287,7 @@ end
 function demo_themes(y, xv, yv, matrix)
     CairoMakie.activate!() # hide
     fig, _ = series(y; labels=["$i" for i = 1:6], markersize=10,
-        color=:Set1, figure=(; resolution=(600, 300)),
+        color=:Set1, figure=(; size=(600, 300)),
         axis=(; xlabel="time (s)", ylabel="Amplitude",
             title="Measurements"))
     hmap = heatmap!(xv, yv, matrix; colormap=:plasma)
@@ -308,7 +308,7 @@ function multiple_example_themes()
         labels = ["$i" for i = 1:n]
         fig, _ = series(y; labels=labels, markersize=10, color=:Set1,
             axis=(; xlabel="time (s)", ylabel="Amplitude",
-                title="Measurements"), figure=(; resolution=(600, 300)))
+                title="Measurements"), figure=(; size=(600, 300)))
         xh = LinRange(-3, 0.5, 20)
         yh = LinRange(-3.5, 3.5, 20)
         hmap = heatmap!(xh, yh, randn(20, 20); colormap=:plasma)
@@ -341,7 +341,7 @@ function demo_figure()
     labs=["sin(x)","cos(x)","-sin(x)","-cos(x)","cos(x)/2","-cos(x)/2"]
     # figure
     fig = Figure(figure_padding=(10,15,5,35),
-        resolution = (900,600), fontsize = 20)
+        size = (900,600), fontsize = 20)
     ax1 = Axis(fig[1,1]; xlabel="x", ylabel="y")
     ax2 = Axis(fig[1,2]; xlabel="x", ylabel="pdf")
     ax3 = Axis(fig[2,1:2]; xlabel="x", ylabel="y")
@@ -373,7 +373,7 @@ end
 
 function themes_gallery()
     GLMakie.activate!() # hide
-    fig = Figure(resolution=(1200, 1250))
+    fig = Figure(size=(1200, 1250))
     aximg = [Axis(fig[i,j], aspect = DataAspect()) for i in 1:3 for j in 1:2]
     img = demo_figure()
     image!(aximg[1], rotr90(img), interpolate=false)
@@ -413,7 +413,7 @@ function set_colors_and_cycle()
 
     axis = (; xlabel=L"x(\theta)", ylabel=L"y(\theta)",
         title="Epicycloid", aspect=DataAspect())
-    figure = (; resolution=(600, 400), font="CMU Serif")
+    figure = (; size=(600, 400), font="CMU Serif")
 
     fig, ax, _ = lines(x(1, 1, θ), y(1, 1, θ); color="firebrick1", # string
         label=L"1.0", axis=axis, figure=figure)
@@ -457,7 +457,7 @@ function scatters_and_lines()
     xh = range(4, 6, 25)
     yh = range(70, 95, 25)
     h = randn(25, 25)
-    fig = Figure(resolution=(600, 400), font="CMU Serif")
+    fig = Figure(size=(600, 400), font="CMU Serif")
     ax = Axis(fig[1, 1]; xlabel=L"x", ylabel=L"f(x,a)")
     for i in x
         lines!(ax, x, i .* x; label=latexstring("$(i) x"))
@@ -476,7 +476,7 @@ function first_layout()
     CairoMakie.activate!() # hide
     seed!(123)
     x, y, z = randn(6), randn(6), randn(6)
-    fig = Figure(resolution=(600, 400), backgroundcolor=:snow2)
+    fig = Figure(size=(600, 400), backgroundcolor=:snow2)
     ax = Axis(fig[1, 1], backgroundcolor=:white)
     pltobj = scatter!(ax, x, y; color=z, label="scatters")
     lines!(ax, x, 1.1y; label="line")
@@ -493,7 +493,7 @@ function first_layout_fixed()
     CairoMakie.activate!() # hide
     seed!(123)
     x, y, z = randn(6), randn(6), randn(6)
-    fig = Figure(figure_padding=(0, 3, 5, 2), resolution=(600, 400),
+    fig = Figure(figure_padding=(0, 3, 5, 2), size=(600, 400),
         backgroundcolor=:snow2, font="CMU Serif")
     ax = Axis(fig[1, 1], xlabel=L"x", ylabel=L"y",
         title="Layout example", backgroundcolor=:white)
@@ -523,7 +523,7 @@ function complex_layout_double_axis()
     x = range(0, 1, 10)
     y = range(0, 1, 10)
     z = rand(10, 10)
-    fig = Figure(resolution=(700, 400),
+    fig = Figure(size=(700, 400),
         font="CMU Serif",
         backgroundcolor=:snow2
         )
@@ -557,7 +557,7 @@ function squares_layout()
     CairoMakie.activate!() # hide
     seed!(123)
     letters = reshape(collect('a':'d'), (2, 2))
-    fig = Figure(resolution=(600, 400), fontsize=14, font="CMU Serif",
+    fig = Figure(size=(600, 400), fontsize=14, font="CMU Serif",
         backgroundcolor=:snow2)
     axs = [Axis(fig[i, j], aspect=DataAspect()) for i = 1:2, j = 1:2]
     hms = [heatmap!(axs[i, j], randn(10, 10), colorrange=(-2, 2))
@@ -578,7 +578,7 @@ function mixed_mode_layout()
     CairoMakie.activate!() # hide
     seed!(123)
     longlabels = ["$(today() - Day(1))", "$(today())", "$(today() + Day(1))"]
-    fig = Figure(resolution=(600, 400), fontsize=12,
+    fig = Figure(size=(600, 400), fontsize=12,
         backgroundcolor=:snow2, font="CMU Serif")
     ax1 = Axis(fig[1, 1], xlabel="x", alignmode=Mixed(bottom=0))
     ax2 = Axis(fig[1, 2], xticklabelrotation=π/2, alignmode=Mixed(bottom=0),
@@ -674,7 +674,7 @@ end
 
 function figure_axis_inset()
     CairoMakie.activate!() # hide
-    fig = Figure(resolution=(600, 400))
+    fig = Figure(size=(600, 400))
     ax = Axis(fig[1, 1], backgroundcolor=:white)
     inset_ax1 = add_axis_inset(fig[1, 1]; bgcolor=:snow2,
         halign=:left, valign=:center,
@@ -695,7 +695,7 @@ end
 
 function figure_box_inset()
     CairoMakie.activate!() # hide
-    fig = Figure(resolution=(600, 400))
+    fig = Figure(size=(600, 400))
     ax = Axis(fig[1, 1], backgroundcolor=:white)
     inset_ax1 = add_box_inset(fig; bgcolor=:snow2,
         left=100, right=250, bottom=200, top=300)
@@ -719,7 +719,7 @@ function scatters_in_3D()
     aspect=(1, 1, 1)
     perspectiveness=0.5
     # the figure
-    fig = Figure(; resolution=(1200, 400))
+    fig = Figure(; size=(1200, 400))
     ax1 = Axis3(fig[1, 1]; aspect, perspectiveness)
     ax2 = Axis3(fig[1, 2]; aspect, perspectiveness)
     ax3 = Axis3(fig[1, 3]; aspect=:data, perspectiveness)
@@ -741,7 +741,7 @@ function lines_in_3D()
     aspect=(1, 1, 1)
     perspectiveness=0.5
     # the figure
-    fig = Figure(; resolution=(1200, 500))
+    fig = Figure(; size=(1200, 500))
     ax1 = Axis3(fig[1, 1]; aspect, perspectiveness)
     ax2 = Axis3(fig[1, 2]; aspect, perspectiveness)
     ax3 = Axis3(fig[1, 3]; aspect=:data, perspectiveness)
@@ -774,7 +774,7 @@ function plot_peaks_function()
     GLMakie.activate!() # hide
     x, y, z = peaks()
     x2, y2, z2 = peaks(; n=15)
-    fig = Figure(resolution=(1200, 400))
+    fig = Figure(size=(1200, 400))
     axs = [Axis3(fig[1, i]; aspect=(1, 1, 1)) for i = 1:3]
     hm = surface!(axs[1], x, y, z)
     wireframe!(axs[2], x2, y2, z2)
@@ -786,7 +786,7 @@ end
 function heatmap_contour_and_contourf()
     GLMakie.activate!() # hide
     x, y, z = peaks()
-    fig = Figure(resolution=(1200, 400))
+    fig = Figure(size=(1200, 400))
     axs = [Axis(fig[1, i]; aspect=DataAspect()) for i = 1:3]
     hm = heatmap!(axs[1], x, y, z)
     contour!(axs[2], x, y, z; levels=20)
@@ -798,7 +798,7 @@ end
 function heatmap_contour_and_contourf_in_a_3d_plane()
     GLMakie.activate!() # hide
     x, y, z = peaks()
-    fig = Figure(resolution=(1200, 400))
+    fig = Figure(size=(1200, 400))
     axs = [Axis3(fig[1, i]) for i = 1:3]
     hm = heatmap!(axs[1], x, y, z)
     contour!(axs[2], x, y, z; levels=20)
@@ -812,7 +812,7 @@ function mixing_surface_contour3d_contour_and_contourf()
     img = testimage("coffee.png")
     x, y, z = peaks()
     cmap = :Spectral_11
-    fig = Figure(resolution=(1200, 800), fontsize=26)
+    fig = Figure(size=(1200, 800), fontsize=26)
     ax1 = Axis3(fig[1, 1]; aspect=(1, 1, 1),
         elevation=π/6, perspectiveness=0.5,
         xzpanelcolor=(:black, 0.75), yzpanelcolor=:black,
@@ -858,7 +858,7 @@ function arrows_and_streamplot_in_3d()
     lengths = norm.(ns)
     flowField(x, y, z) = Point(-y + x * (-1 + x^2 + y^2)^2,
         x + y * (-1 + x^2 + y^2)^2, z + x * (y - z^2))
-    fig = Figure(resolution=(1200, 800), fontsize=26)
+    fig = Figure(size=(1200, 800), fontsize=26)
     axs = [Axis3(fig[1, i]; aspect=(1,1,1), perspectiveness=0.5) for i=1:2]
     # http://makie.juliaplots.org/stable/plotting_functions/arrows.html # hide
     arrows!(axs[1], ps, ns, color=lengths, arrowsize=Vec3f(0.2, 0.2, 0.3),
@@ -884,7 +884,7 @@ function mesh_volume_contour()
     # cloud points for volume
     x = y = z = 1:10
     vals = randn(10, 10, 10)
-    fig = Figure(resolution=(1200, 400))
+    fig = Figure(size=(1200, 400))
     axs = [Axis3(fig[1, i]; aspect=(1,1,1), perspectiveness=0.5) for i=1:3]
     mesh!(axs[1], recmesh; color=colors, colormap=:rainbow, shading=false)
     mesh!(axs[1], spheremesh; color=(:white, 0.25), transparency=true)
@@ -898,7 +898,7 @@ function filled_line_and_linesegments_in_3D()
     lower = [Point3f(i, -i, 0) for i in range(0, 3, 100)]
     upper = [Point3f(i, -i, sin(i) * exp(-(i + i)))
         for i in range(0, 3, length=100)]
-    fig = Figure(resolution=(1200, 800))
+    fig = Figure(size=(1200, 800))
     axs = [Axis3(fig[1, i]; elevation=π/6, perspectiveness=0.5) for i=1:2]
     band!(axs[1], lower, upper; color=repeat(norm.(upper), outer=2),
         colormap=:CMRmap)
@@ -926,7 +926,7 @@ function grid_spheres_and_rectangle_as_plate()
     aspect = :data
     # now the figure
     fig = with_theme(theme_dark()) do
-        fig = Figure(resolution=(1200, 800))
+        fig = Figure(size=(1200, 800))
         ax1 = Axis3(fig[1, 1]; aspect, perspectiveness, azimuth=0.72)
         ax2 = Axis3(fig[1, 2]; aspect, perspectiveness)
         meshscatter!(ax1, spheresGrid; color=colorSphere, markersize=1,
@@ -955,7 +955,7 @@ function histogram_or_bars_in_3d()
     cmap = get(colorschemes[cbarPal], ztmp) # hide
     cmap2 = reshape(cmap, size(z)) # hide
     ztmp2 = abs.(z) ./ maximum(abs.(z)) .+ 0.15 # hide
-    fig = Figure(resolution=(1200, 800), fontsize=26)
+    fig = Figure(size=(1200, 800), fontsize=26)
     ax1 = Axis3(fig[1, 1]; aspect=(1,1,1), elevation=π/6,
         perspectiveness=0.5)
     ax2 = Axis3(fig[1, 2]; aspect=(1,1,1), perspectiveness=0.5)

--- a/src/stats.jl
+++ b/src/stats.jl
@@ -12,7 +12,7 @@ function statistics_graph()
     points = hcat(points...)'
     ##
     fig, ax, = lines(ellipse.(u);
-        figure=(; resolution=(600, 400)),
+        figure=(; size=(600, 400)),
         axis=(; aspect=1))
     lines!(ellipse.(u; a=1.5, b=3, k=-5))
     lines!(points[:, 1], points[:, 2])
@@ -57,7 +57,7 @@ dens(ax, rand_d, color) = density!(ax, rand_d; color=color, strokewidth=1.5, str
 
 function plot_central()
     CairoMakie.activate!() # hide
-    fig = Figure(; resolution=(600, 400))
+    fig = Figure(; size=(600, 400))
     ax1 = Axis(fig[1, 1]; limits=((3, 20), nothing))
     ax2 = Axis(fig[2, 1]; limits=((3, 20), nothing))
     d1, rand_d1 = normal_dist(10, 1)
@@ -136,7 +136,7 @@ end
 
 function plot_dispersion_std()
     CairoMakie.activate!() # hide
-    fig = Figure(; resolution=(600, 400))
+    fig = Figure(; size=(600, 400))
     ax1 = Axis(fig[1, 1]; limits=((3, 20), nothing))
     ax2 = Axis(fig[2, 1]; limits=((3, 20), nothing))
     d1, rand_d1 = normal_dist(10, 1)
@@ -198,7 +198,7 @@ end
 
 function plot_dispersion_mad()
     CairoMakie.activate!() # hide
-    fig = Figure(; resolution=(600, 400))
+    fig = Figure(; size=(600, 400))
     ax1 = Axis(fig[1, 1]; limits=((3, 20), nothing))
     ax2 = Axis(fig[2, 1]; limits=((3, 20), nothing))
     d1, rand_d1 = normal_dist(10, 1)
@@ -259,7 +259,7 @@ end
 
 function plot_dispersion_iqr()
     CairoMakie.activate!() # hide
-    fig = Figure(; resolution=(600, 400))
+    fig = Figure(; size=(600, 400))
     ax1 = Axis(fig[1, 1]; limits=((3, 20), nothing))
     ax2 = Axis(fig[2, 1]; limits=((3, 20), nothing))
     d1, rand_d1 = normal_dist(10, 1)
@@ -357,7 +357,7 @@ end
 function plot_corr()
     seed!(123)
     CairoMakie.activate!() # hide
-    fig = Figure(; resolution=(600, 600))
+    fig = Figure(; size=(600, 600))
     corrs = [0.5, -0.5, 0.8, -0.8]
     ds = [MvNormal([1 i; i 1]) for i in corrs]
     d0 = MvNormal(2, 1)
@@ -398,7 +398,7 @@ end
 
 function plot_normal_lognormal()
     CairoMakie.activate!() # hide
-    fig = Figure(; resolution=(600, 400))
+    fig = Figure(; size=(600, 400))
     ax = Axis(fig[1, 1]; limits=((3, 20), nothing))
     _, rand_d1 = normal_dist(10, 1)
     _, rand_d2 = lognormal_dist(10, 1.3)
@@ -414,7 +414,7 @@ function plot_discrete_continuous()
     discrete = Binomial(10, 0.6)
     continuous = Distributions.Normal(6, 2)
     CairoMakie.activate!() # hide
-    fig = Figure(; resolution=(600, 400))
+    fig = Figure(; size=(600, 400))
     ax1 = Axis(fig[1, 1]; limits=((0.5, 10.5), nothing), title="Discrete", titlesize=20)
     ax2 = Axis(fig[1, 2]; limits=((-1, 13), nothing), title="Continuous", titlesize=20)
     hist!(ax1, rand(discrete, 1_000); color=(:dodgerblue, 0.5), strokewidth=1.5, strokecolor=(:black, 0.5), bins=10, normalization=:pdf)
@@ -427,7 +427,7 @@ end
 function plot_pmf()
     dice = DiscreteUniform(1, 6)
     CairoMakie.activate!() # hide
-    fig = Figure(; resolution=(600, 400))
+    fig = Figure(; size=(600, 400))
     ax = Axis(fig[1, 1]; xticks=1:6, limits=(nothing, (0, 0.2)), ylabel="pmf")
     barplot!(ax, 1:6, Distributions.pdf(dice, 1:6); color=(:grey, 0.25), strokewidth=1.5, strokecolor=(:black, 0.5))
     return fig
@@ -436,7 +436,7 @@ end
 function plot_pdf()
     d = Distributions.Normal()
     CairoMakie.activate!() # hide
-    fig = Figure(; resolution=(600, 400))
+    fig = Figure(; size=(600, 400))
     ax = Axis(fig[1, 1]; xticks=-3:3, ylabel="pdf")
     range = -3:0.01:3.0
     subset = 1:0.01:2.0
@@ -447,7 +447,7 @@ end
 
 function plot_cdf(type::AbstractString)
     CairoMakie.activate!() # hide
-    fig = Figure(; resolution=(600, 400))
+    fig = Figure(; size=(600, 400))
     if type == "discrete"
         d = Distributions.DiscreteUniform(1, 6)
         range = 1:6
@@ -499,7 +499,7 @@ function plot_anscombe()
     df = anscombe_quartet()
     filter_anscombe(idx) = filter(row -> row.dataset == idx, df)
     CairoMakie.activate!() # hide
-    fig = Figure(; resolution=(600, 600))
+    fig = Figure(; size=(600, 600))
     axs = [Axis(fig[i, j]; limits=((3, 20), (2.5, 14)),
         xticks=4:2:20, yticks=2:14)
            for i = 1:2, j = 1:2]


### PR DESCRIPTION
The only one I didn't fixed was `Warning: argument help isn't currently implemented correctly` since this is hardcoded in Makie (https://github.com/MakieOrg/Makie.jl/blob/822d11cf1e9751084a276f79b616b03afdc43e2d/src/documentation/documentation.jl#L63)...
