### PR TITLE
ci: set `JULIA_NUM_THREADS` to `"auto"` by default

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   BuildAndDeploy:
     runs-on: ubuntu-latest
+    env:
+      JULIA_NUM_THREADS: "auto"
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
I don't know when GitHub will give us runners with more than 2 threads, so this is future-proofing...