### PR TITLE
Set Julia version to 1.10

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -29,7 +29,7 @@ jobs:
 
       - uses: julia-actions/setup-julia@v2
         with:
-          version: "1.11"
+          version: "1.10" # LTS
 
       - name: Copy over the Portuguese output
         shell: bash


### PR DESCRIPTION
In response to

> Why not pin to 1.10 since that is the new LTS?

https://github.com/JuliaDataScience/JuliaDataScience/pull/348#issuecomment-2405773369